### PR TITLE
Windows installer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,8 @@ indent_size = 4
 [*.fx]
 indent_style = tab
 indent_size = 2
+
+# WiX code files
+[*.{wxs,wxi,wxl}]
+indent_style = space
+indent_size = 2

--- a/Hero6.sln
+++ b/Hero6.sln
@@ -38,6 +38,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{8FAAE2
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hero6.UserInterface.SierraVGA", "src\Hero6.UserInterface.SierraVGA\Hero6.UserInterface.SierraVGA.csproj", "{9C6A0DA4-892E-45C0-AFC7-B6D46F940329}"
 EndProject
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "Hero6.Installer.Windows", "src\Hero6.Installer.Windows\Hero6.Installer.Windows.wixproj", "{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Hero6\Hero6.projitems*{b0b2294d-fb45-47c3-a645-6c5884e7cfab}*SharedItemsImports = 4
@@ -296,6 +298,26 @@ Global
 		{9C6A0DA4-892E-45C0-AFC7-B6D46F940329}.WindowsDX Release|Any CPU.Build.0 = Release|Any CPU
 		{9C6A0DA4-892E-45C0-AFC7-B6D46F940329}.WindowsDX Release|x86.ActiveCfg = Release|Any CPU
 		{9C6A0DA4-892E-45C0-AFC7-B6D46F940329}.WindowsDX Release|x86.Build.0 = Release|Any CPU
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Android Debug|Any CPU.ActiveCfg = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Android Debug|x86.ActiveCfg = Debug|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Android Debug|x86.Build.0 = Debug|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Android Release|Any CPU.ActiveCfg = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Android Release|x86.ActiveCfg = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Android Release|x86.Build.0 = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Debug|x86.ActiveCfg = Debug|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Debug|x86.Build.0 = Debug|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Release|Any CPU.ActiveCfg = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Release|x86.ActiveCfg = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.Release|x86.Build.0 = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.WindowsDX Debug|Any CPU.ActiveCfg = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.WindowsDX Debug|Any CPU.Build.0 = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.WindowsDX Debug|x86.ActiveCfg = Debug|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.WindowsDX Debug|x86.Build.0 = Debug|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.WindowsDX Release|Any CPU.ActiveCfg = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.WindowsDX Release|Any CPU.Build.0 = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.WindowsDX Release|x86.ActiveCfg = Release|x86
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F}.WindowsDX Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -312,6 +334,7 @@ Global
 		{6BEE8AAC-A058-40B2-9009-76416AA682BA} = {CB9FBBED-6835-4C03-AC4B-60ED8763AFC9}
 		{18480A92-0609-481E-99AD-6C3346829573} = {CB9FBBED-6835-4C03-AC4B-60ED8763AFC9}
 		{9C6A0DA4-892E-45C0-AFC7-B6D46F940329} = {C7901A1A-E22C-468F-9E9A-9A891598E7D8}
+		{FC20ADDD-6655-49FE-9C8F-9AE16C08682F} = {887BCA83-96AC-4E83-BAF5-567626AF670B}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/LICENSE.THIRDPARTY.md
+++ b/LICENSE.THIRDPARTY.md
@@ -12,6 +12,13 @@ Paket is a tool for managing and organizing external projects in form of NuGet p
 * [Repository](https://github.com/fsprojects/Paket)
 * [License](https://github.com/fsprojects/Paket/blob/master/LICENSE.txt)
 
+#### WiX
+WiX is a development kit for creating .msi installers. It is licensed under the MS-RL-license.
+
+* [Homepage](http://wixtoolset.org/)
+* [Repository](https://github.com/wixtoolset/wix3)
+* [License](https://github.com/wixtoolset/wix3/blob/develop/LICENSE.TXT)
+
 ### NuGet-packages
 The C# code base has dependencies on third-party frameworks that is downloaded before compilation via the NuGet system.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Ideally, we want anyone to be able to build Hero6 on any OS with any IDE. This i
   * If you are not a dedicated coder or contributor to the Hero6 project and want to check out the bleeding-edge builds, you will most likely prefer MonoDevelop/Xamarin Studio. While the Visual Studio IDE takes hours to install and requires several GBs of your disk, Xamarin Studio installs in a few minutes and requires approximately 100+ MBs.
   * [Rider EAP](https://www.jetbrains.com/rider/) has been tested and works with Hero6. However, we will not maintain this compatibility until Rider receives a public release and its conditions for use are well defined.
   * If you want to run our unit tests and are also using Visual Studio you will need the [NUnit3 Test Adapter](https://visualstudiogallery.msdn.microsoft.com/0da0f6bd-9bb6-4ae3-87a8-537788622f2d).
+  * If you want to build the Windows installer you will need Visual Studio with the [WiX Toolset](http://wixtoolset.org/).
 * If you are using Windows 10 you need to enable [.NET 2.0](http://anewdomain.net/2013/10/21/how-to-enable-net-framework-2-0-and-3-5-in-windows-8-1-for-older-programs/).
 
 #####Instructions

--- a/src/Hero6.Installer.Windows/Data.wxi
+++ b/src/Hero6.Installer.Windows/Data.wxi
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include>
+  <?define name="Hero6" ?>
+  <?define company="Late Start Studio" ?>
+  <?define version="0.1.0.0" ?>
+</Include>

--- a/src/Hero6.Installer.Windows/Hero6.Installer.Windows.wixproj
+++ b/src/Hero6.Installer.Windows/Hero6.Installer.Windows.wixproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>3.10</ProductVersion>
+    <ProjectGuid>fc20addd-6655-49fe-9c8f-9ae16c08682f</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputName>Hero6</OutputName>
+    <OutputType>Package</OutputType>
+    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+    <Name>Hero6.Installer.Windows</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Product.wxs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Hero6.WindowsDX\Hero6.WindowsDX.csproj">
+      <Name>Hero6.WindowsDX</Name>
+      <Project>{b0b2294d-fb45-47c3-a645-6c5884e7cfab}</Project>
+      <Private>True</Private>
+      <DoNotHarvest>True</DoNotHarvest>
+      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
+      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <WixExtension Include="WixUIExtension">
+      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
+      <Name>WixUIExtension</Name>
+    </WixExtension>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Data.wxi" />
+  </ItemGroup>
+  <Import Project="$(WixTargetsPath)" />
+  <!--
+	To modify your build process, add your task inside one of the targets below and uncomment it.
+	Other similar extension points exist, see Wix.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/src/Hero6.Installer.Windows/Product.wxs
+++ b/src/Hero6.Installer.Windows/Product.wxs
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?include Data.wxi ?>
+
+  <Product Id="*" Name="$(var.name)" Language="1033" Version="$(var.version)" Manufacturer="$(var.company)" UpgradeCode="040E1B1F-AC35-4CC4-A20A-0287F55E2FF0">
+    <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate />
+
+    <Feature Id="$(var.name)" Title="$(var.name)" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+      <ComponentGroupRef Id="BackgroundAlbionComponents" />
+      <ComponentGroupRef Id="HeroSpriteComponents" />
+      <ComponentGroupRef Id="LlewellaSpriteComponents" />
+      <ComponentGroupRef Id="CursorSpriteComponents" />
+      <ComponentGroupRef Id="FontComponents" />
+      <ComponentGroupRef Id="BentSwordComponents" />
+      <ComponentGroupRef Id="ProductDocuments" />
+      <ComponentGroupRef Id="StartMenuComponents" />
+    </Feature>
+
+    <Icon Id="Icon.ico" SourceFile="$(var.Hero6.WindowsDX.ProjectDir)Icon.ico"/>
+    <Property Id="ARPPRODUCTICON" Value="icon.ico" />
+
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
+    <UIRef Id="WixUI_InstallDir"/>
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder" Name="PFiles">
+        <Directory Id="COMPANYFOLDER" Name="$(var.company)">
+          <Directory Id="INSTALLFOLDER" Name="$(var.name)">
+            <Directory Id="CONTENTFOLDER" Name="Content">
+              <Directory Id="BACKGROUNDSFOLDER" Name="Backgrounds">
+                <Directory Id="ALBIONFOLDER" Name="Albion"/>
+              </Directory>
+              <Directory Id="EMPTYKEYSGENERATEDFOLDER" Name="EmptyKeysGenerated">
+                <Directory Id="GUIFOLDER" Name="GUI">
+                  <Directory Id="SIERRAVGAFOLDER" Name="SierraVGA"/>
+                </Directory>
+              </Directory>
+              <Directory Id="SPRITESFOLDER" Name="Sprites">
+                <Directory Id="CHARACTERSFOLDER" Name="Characters">
+                  <Directory Id="HEROFOLDER" Name="Hero"/>
+                  <Directory Id="NPCSFOLDER" Name="NPCs">
+                    <Directory Id="LLEWELLAFOLDER" Name="Llewella"/>
+                  </Directory>
+                </Directory>
+                <Directory Id="GUISFOLDER" Name="GUIs">
+                  <Directory Id="CURSORSFOLDER" Name="Cursors"/>
+                </Directory>
+                <Directory Id="OBJECTSFOLDER" Name="Objects">
+                  <Directory Id="PICKUPSFOLDER" Name="Pick-Up">
+                    <Directory Id="BENTSWORDFOLDER" Name="Bent Sword"/>
+                  </Directory>
+                </Directory>
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+      <Directory Id="ProgramMenuFolder">
+        <Directory Id="APPLICATIONPROGRAMFOLDER" Name="$(var.name)"/>
+      </Directory>
+    </Directory>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+      <Component Id="$(var.name).exe" Guid="F9913C3D-BFC7-43B9-B50C-5023F8802C32">
+        <File Id="$(var.name).exe" Name="$(var.name).exe" Source="$(var.Hero6.WindowsDX.TargetDir)$(var.name).exe" />
+      </Component>
+      <Component Id="AdventureGame.dll" Guid="3A0BB201-A128-4383-9C4D-6BEC6A3168EF">
+        <File Id="AdventureGame.dll" Name="AdventureGame.dll" Source="$(var.Hero6.WindowsDX.TargetDir)AdventureGame.dll" />
+      </Component>
+      <Component Id="Collections.dll" Guid="D51AE974-B17B-4718-9524-B73AAF967D57">
+        <File Id="Collections.dll" Name="Collections.dll" Source="$(var.Hero6.WindowsDX.TargetDir)Collections.dll" />
+      </Component>
+      <Component Id="EmptyKeys.UserInterface.Core.dll" Guid="3AF32F96-2660-4CF6-B9ED-AB0F7A42A078">
+        <File Id="EmptyKeys.UserInterface.Core.dll" Name="EmptyKeys.UserInterface.Core.dll" Source="$(var.Hero6.WindowsDX.TargetDir)EmptyKeys.UserInterface.Core.dll" />
+      </Component>
+      <Component Id="EmptyKeys.UserInterface.Debug.dll" Guid="440E11FA-2C16-4090-8E43-92BE4738A828">
+        <File Id="EmptyKeys.UserInterface.Debug.dll" Name="EmptyKeys.UserInterface.Debug.dll" Source="$(var.Hero6.WindowsDX.TargetDir)EmptyKeys.UserInterface.Debug.dll" />
+      </Component>
+      <Component Id="EmptyKeys.UserInterface.dll" Guid="F6CD12E7-612A-4110-BB6C-E6043CEEF8E2">
+        <File Id="EmptyKeys.UserInterface.dll" Name="EmptyKeys.UserInterface.dll" Source="$(var.Hero6.WindowsDX.TargetDir)EmptyKeys.UserInterface.dll" />
+      </Component>
+      <Component Id="EmptyKeys.UserInterface.MonoGame.dll" Guid="2FAA3A17-0E10-49E0-9987-E927B525DB5F">
+        <File Id="EmptyKeys.UserInterface.MonoGame.dll" Name="EmptyKeys.UserInterface.MonoGame.dll" Source="$(var.Hero6.WindowsDX.TargetDir)EmptyKeys.UserInterface.MonoGame.dll" />
+      </Component>
+      <Component Id="Hero6.Campaigns.RitesOfPassage.dll" Guid="18F3A607-8EB1-4EC9-8C3A-B95FD03C8284">
+        <File Id="Hero6.Campaigns.RitesOfPassage.dll" Name="Hero6.Campaigns.RitesOfPassage.dll" Source="$(var.Hero6.WindowsDX.TargetDir)Hero6.Campaigns.RitesOfPassage.dll" />
+      </Component>
+      <Component Id="Hero6.UserInterface.SierraVGA.dll" Guid="F8978BBA-3A8F-483F-B993-0FD10333C303">
+        <File Id="Hero6.UserInterface.SierraVGA.dll" Name="Hero6.UserInterface.SierraVGA.dll" Source="$(var.Hero6.WindowsDX.TargetDir)Hero6.UserInterface.SierraVGA.dll" />
+      </Component>
+      <Component Id="MonoGame.Framework.dll" Guid="ECF67526-8E9B-4AF4-B6A4-E7EE8B657A03">
+        <File Id="MonoGame.Framework.dll" Name="MonoGame.Framework.dll" Source="$(var.Hero6.WindowsDX.TargetDir)MonoGame.Framework.dll" />
+      </Component>
+      <Component Id="PriorityQueue.dll" Guid="41A758FA-A5C7-4D0E-9443-DBFEC177DFBA">
+        <File Id="PriorityQueue.dll" Name="Priority Queue.dll" Source="$(var.Hero6.WindowsDX.TargetDir)Priority Queue.dll" />
+      </Component>
+      <Component Id="Search.dll" Guid="5BDFA690-0D91-4DAB-A3BA-290B074A9D11">
+        <File Id="Search.dll" Name="Search.dll" Source="$(var.Hero6.WindowsDX.TargetDir)Search.dll" />
+      </Component>
+      <Component Id="SharpDX.Direct2D1.dll" Guid="9C81DFB9-679A-4917-A86F-C20E5FDF2BFC">
+        <File Id="SharpDX.Direct2D1.dll" Name="SharpDX.Direct2D1.dll" Source="$(var.Hero6.WindowsDX.TargetDir)SharpDX.Direct2D1.dll" />
+      </Component>
+      <Component Id="SharpDX.Direct3D9.dll" Guid="6987C9DD-05A2-4256-AB46-595B72806198">
+        <File Id="SharpDX.Direct3D9.dll" Name="SharpDX.Direct3D9.dll" Source="$(var.Hero6.WindowsDX.TargetDir)SharpDX.Direct3D9.dll" />
+      </Component>
+      <Component Id="SharpDX.Direct3D11.dll" Guid="1990D2D6-9C9C-425D-A209-324B4E5644DB">
+        <File Id="SharpDX.Direct3D11.dll" Name="SharpDX.Direct3D11.dll" Source="$(var.Hero6.WindowsDX.TargetDir)SharpDX.Direct3D11.dll" />
+      </Component>
+      <Component Id="SharpDX.dll" Guid="350E11D6-02E1-4C8D-8AA6-30ED91AE0415">
+        <File Id="SharpDX.dll" Name="SharpDX.dll" Source="$(var.Hero6.WindowsDX.TargetDir)SharpDX.dll" />
+      </Component>
+      <Component Id="SharpDX.DXGI.dll" Guid="4DEF8B6B-0EF3-4F72-85AA-43D519E05637">
+        <File Id="SharpDX.DXGI.dll" Name="SharpDX.DXGI.dll" Source="$(var.Hero6.WindowsDX.TargetDir)SharpDX.DXGI.dll" />
+      </Component>
+      <Component Id="SharpDX.MediaFoundation.dll" Guid="D1B744F6-5B13-43DD-A896-2FF05234EC55">
+        <File Id="SharpDX.MediaFoundation.dll" Name="SharpDX.MediaFoundation.dll" Source="$(var.Hero6.WindowsDX.TargetDir)SharpDX.MediaFoundation.dll" />
+      </Component>
+      <Component Id="SharpDX.RawInput.dll" Guid="6FFF92CB-DE40-4901-8C3F-FEF8BD98C808">
+        <File Id="SharpDX.RawInput.dll" Name="SharpDX.RawInput.dll" Source="$(var.Hero6.WindowsDX.TargetDir)SharpDX.RawInput.dll" />
+      </Component>
+      <Component Id="SharpDX.XAudio2.dll" Guid="4F550EA1-8FDD-4A04-8B9C-106CD85CACEB">
+        <File Id="SharpDX.XAudio2.dll" Name="SharpDX.XAudio2.dll" Source="$(var.Hero6.WindowsDX.TargetDir)SharpDX.XAudio2.dll" />
+      </Component>
+      <Component Id="SharpDX.XInput.dll" Guid="06D1AE0F-834D-473F-8238-8250CEEE6D75">
+        <File Id="SharpDX.XInput.dll" Name="SharpDX.XInput.dll" Source="$(var.Hero6.WindowsDX.TargetDir)SharpDX.XInput.dll" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="BackgroundAlbionComponents" Directory="ALBIONFOLDER">
+      <Component Id="Fountain.xnb" Guid="854EB704-A451-4D02-9E2B-70AFE6C4951A">
+        <File Id="Fountain.xnb" Name="Fountain.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Backgrounds/Albion/Fountain.xnb" />
+      </Component>
+      <Component Id="FountainRegions.xnb" Guid="364FAA8D-B7B5-40B4-9EFD-ECE7FCECB69C">
+        <File Id="FountainRegions.xnb" Name="FountainRegions.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Backgrounds/Albion/FountainRegions.xnb" />
+      </Component>
+      <Component Id="FountainWalkArea.xnb" Guid="C0FD1FE4-B995-412E-AF75-32A622082B86">
+        <File Id="FountainWalkArea.xnb" Name="FountainWalkArea.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Backgrounds/Albion/FountainWalkArea.xnb" />
+      </Component>
+      <Component Id="HillOverAlbion.xnb" Guid="4578D284-EDC7-4777-8D21-A75ED667CE16">
+        <File Id="HillOverAlbion.xnb" Name="HillOverAlbion.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Backgrounds/Albion/HillOverAlbion.xnb" />
+      </Component>
+      <Component Id="HillOverAlbionRegions.xnb" Guid="2650AB1B-9B52-4DD2-A223-43E3B39DB8AF">
+        <File Id="HillOverAlbionRegions.xnb" Name="HillOverAlbionRegions.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Backgrounds/Albion/HillOverAlbionRegions.xnb" />
+      </Component>
+      <Component Id="HillOverAlbionWalkArea.xnb" Guid="93D2EF76-6855-4C36-8D13-D4B39D69B91C">
+        <File Id="HillOverAlbionWalkArea.xnb" Name="HillOverAlbionWalkArea.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Backgrounds/Albion/HillOverAlbionWalkArea.xnb" />
+      </Component>
+    </ComponentGroup>
+    <ComponentGroup Id="HeroSpriteComponents" Directory="HEROFOLDER">
+      <Component Id="HeroWalkCenterDown.xnb" Guid="907A000C-366D-4DBF-8D0E-95C6D5CDAC02">
+        <File Id="HeroWalkCenterDown.xnb" Name="HeroWalkCenterDown.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Characters/Hero/HeroWalkCenterDown.xnb" />
+      </Component>
+      <Component Id="HeroWalkCenterUp.xnb" Guid="7186B1B4-A527-4249-AB9F-B57C28A4775A">
+        <File Id="HeroWalkCenterUp.xnb" Name="HeroWalkCenterUp.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Characters/Hero/HeroWalkCenterUp.xnb" />
+      </Component>
+      <Component Id="HeroWalkLeftCenter.xnb" Guid="5A2F917D-0C80-4D68-A767-BC978660A02A">
+        <File Id="HeroWalkLeftCenter.xnb" Name="HeroWalkLeftCenter.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Characters/Hero/HeroWalkLeftCenter.xnb" />
+      </Component>
+      <Component Id="HeroWalkLeftDown.xnb" Guid="7D83611D-B71C-410D-920E-C40662BCB874">
+        <File Id="HeroWalkLeftDown.xnb" Name="HeroWalkLeftDown.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Characters/Hero/HeroWalkLeftDown.xnb" />
+      </Component>
+      <Component Id="HeroWalkLeftUp.xnb" Guid="B706A440-90CD-48CA-AEB7-0A141441C2BC">
+        <File Id="HeroWalkLeftUp.xnb" Name="HeroWalkLeftUp.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Characters/Hero/HeroWalkLeftUp.xnb" />
+      </Component>
+      <Component Id="HeroWalkRightCenter.xnb" Guid="E71A7DE6-C8B6-4C7B-A4CA-7F8FC2964EE4">
+        <File Id="HeroWalkRightCenter.xnb" Name="HeroWalkRightCenter.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Characters/Hero/HeroWalkRightCenter.xnb" />
+      </Component>
+      <Component Id="HeroWalkRightDown.xnb" Guid="2FC4E0E1-4EDF-4D6F-A01E-73FD4DFCE4FB">
+        <File Id="HeroWalkRightDown.xnb" Name="HeroWalkRightDown.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Characters/Hero/HeroWalkRightDown.xnb" />
+      </Component>
+      <Component Id="HeroWalkRightUp.xnb" Guid="206F32B7-F8FE-4FC6-B549-53373281D593">
+        <File Id="HeroWalkRightUp.xnb" Name="HeroWalkRightUp.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Characters/Hero/HeroWalkRightUp.xnb" />
+      </Component>
+    </ComponentGroup>
+    <ComponentGroup Id="LlewellaSpriteComponents" Directory="LLEWELLAFOLDER">
+      <Component Id="LlewellaWalkCenterDown.xnb" Guid="C46A8EE9-2EE2-4BEC-BBD6-E202645684A3">
+        <File Id="LlewellaWalkCenterDown.xnb" Name="LlewellaWalkCenterDown.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Characters/NPCs/Llewella/LlewellaWalkCenterDown.xnb" />
+      </Component>
+    </ComponentGroup>
+    <ComponentGroup Id="CursorSpriteComponents" Directory="CURSORSFOLDER">
+      <Component Id="Arrow.xnb" Guid="13A2726A-12BC-4252-ACAB-0B4872F4D8C8">
+        <File Id="Arrow.xnb" Name="Arrow.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/GUIs/Cursors/Arrow.xnb" />
+      </Component>
+    </ComponentGroup>
+    <ComponentGroup Id="FontComponents" Directory="SIERRAVGAFOLDER">
+      <Component Id="Segoe_UI_11.25_Regular.xnb" Guid="7DCCCE3F-8701-47C3-BEB0-29281BE2A565">
+        <File Id="Segoe_UI_11.25_Regular.xnb" Name="Segoe_UI_11.25_Regular.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/EmptyKeysGenerated/GUI/SierraVGA/Segoe_UI_11.25_Regular.xnb" />
+      </Component>
+    </ComponentGroup>
+    <ComponentGroup Id="BentSwordComponents" Directory="BENTSWORDFOLDER">
+      <Component Id="BentSword.xnb" Guid="36969BB5-CEEE-4DFF-8C9B-60679F5C28CD">
+        <File Id="BentSword.xnb" Name="BentSword.xnb" Source="$(var.Hero6.WindowsDX.TargetDir)Content/Sprites/Objects/Pick-Up/Bent Sword/BentSword.xnb" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ProductDocuments" Directory="INSTALLFOLDER">
+      <Component Id="CHANGELOG.md" Guid="DBCE60A6-4B0B-43B6-B88C-7E0B38C61D26">
+        <File Id="CHANGELOG.md" Name="CHANGELOG.md" Source="$(var.Hero6.WindowsDX.TargetDir)CHANGELOG.md" />
+      </Component>
+      <Component Id="COPYRIGHT.md" Guid="6A7054EA-ABE5-4CAF-B644-98EA41E2AEB1">
+        <File Id="COPYRIGHT.md" Name="COPYRIGHT.md" Source="$(var.Hero6.WindowsDX.TargetDir)COPYRIGHT.md" />
+      </Component>
+      <Component Id="LICENSE.ASSETS.md" Guid="8EE33643-CBAE-4D46-A8E3-E4E7F6610BE4">
+        <File Id="LICENSE.ASSETS.md" Name="LICENSE.ASSETS.md" Source="$(var.Hero6.WindowsDX.TargetDir)LICENSE.ASSETS.md" />
+      </Component>
+      <Component Id="LICENSE.CODE.md" Guid="A02820ED-37D7-4A29-BFAD-184FD61D29F0">
+        <File Id="LICENSE.CODE.md" Name="LICENSE.CODE.md" Source="$(var.Hero6.WindowsDX.TargetDir)LICENSE.CODE.md" />
+      </Component>
+      <Component Id="LICENSE.md" Guid="B477AEC8-3BCC-4B9D-BBCC-16EA42BC63D4">
+        <File Id="LICENSE.md" Name="LICENSE.md" Source="$(var.Hero6.WindowsDX.TargetDir)LICENSE.md" />
+      </Component>
+      <Component Id="LICENSE.THIRDPARTY.md" Guid="E43C4CDF-C5C9-4729-90B7-DB03AE02E57A">
+        <File Id="LICENSE.THIRDPARTY.md" Name="LICENSE.THIRDPARTY.md" Source="$(var.Hero6.WindowsDX.TargetDir)LICENSE.THIRDPARTY.md" />
+      </Component>
+      <Component Id="README.md" Guid="6041D9C1-5E76-4E7A-88A4-EADDA9875014">
+        <File Id="README.md" Name="README.md" Source="$(var.Hero6.WindowsDX.TargetDir)README.md" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="StartMenuComponents" Directory="APPLICATIONPROGRAMFOLDER">
+      <Component Id="ApplicationShortcut" Guid="A57B2622-070A-455E-A0E3-41E43DB80075">
+        <Shortcut Id="ApplicationStartMenuShortcut" Name="$(var.name)" Description="$(var.name).exe shortcut" Target="[#$(var.name).exe]" WorkingDirectory="TARGETDIR"/>
+        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+        <RegistryValue Root="HKCU" Key="Software\$(var.company)\$(var.name)" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>


### PR DESCRIPTION
In reference to #1

Added a functional Windows installer for Hero6. The only thing missing as far as I can tell is pre-requisite software(.NET 4.5 and DirectX 9.0c), however everything else should be in place. It has a UI that allows user to choose install location, it installs a shortcut to the start menu, it allows upgrades and other things we would expect from an installer.

I suggest we just postpone the issue of installing pre-requisite software, the most important thing of this PR is that we have a stable and functional installer that we can build and expand further once integrated into our main branches.
