### PR TITLE
Added OS X build to Travis and FAKE build scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,12 +13,21 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
+# F# script files
+indent_style = space
+indent_size = 4
+
 [*.fx]
 indent_style = tab
 indent_size = 2
 
 # WiX code files
 [*.{wxs,wxi,wxl}]
+indent_style = space
+indent_size = 2
+
+# Batch script
+[*.{bat,cmd}]
 indent_style = space
 indent_size = 2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,38 @@
 # Travis-CI Build Script
+# MonoGame v3.5 doesn't work on Travis-CI, both on Linux and OS X because of a bug that breaks
+# compability with older versions of unix like systems
+# http://community.monogame.net/t/pipeline-tool-dllnotfoundexception/6852
 
 language: csharp
 
-solution: Hero6.Linux.sln
+notifications:
+  email: false
 
 os:
   - linux
-#  - osx
-
-addons:
-  apt:
-    packages:
-      - monodevelop
-      - libopenal-dev
-      - ttf-mscorefonts-installer
+  - osx
 
 before_install:
-  # v3.5 doesn't work because of a bug that breaks compability with older versions of Ubuntu
-  # http://community.monogame.net/t/pipeline-tool-dllnotfoundexception/6852
-  #- wget http://www.monogame.net/releases/v3.5.1/monogame-sdk.run
-  #- chmod +x ./monogame-sdk.run
+  - >
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]];
+    then
+      wget http://www.monogame.net/releases/v3.4/MonoGame.Linux.zip;
+      unzip ./MonoGame.Linux.zip;
+    else
+      wget http://www.monogame.net/releases/v3.4/MonoGame.MacOS.pkg;
+    fi;
 
-  # Try previous stable build v3.4
-  - wget http://www.monogame.net/releases/v3.4/MonoGame.Linux.zip
-  - unzip MonoGame.Linux.zip
   - find * -type f -exec chmod 777 {} \;
 
-  - chmod +x ./src/build.sh
-
 install:
-  #- yes | sudo ./monogame-sdk.run # v3.5
-  - sudo ./generate.sh && yes Y|sudo ./monogame-linux.run; #v3.5
+  - >
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]];
+    then
+      sudo ./generate.sh;
+      yes y | sudo ./monogame-linux.run;
+    else
+      sudo installer -allowUntrusted -verboseR -pkg ./MonoGame.MacOS.pkg -target /;
+    fi;
 
 script:
   - cd src

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Welcome to the Hero6 project. This readme should be included in your copy of Her
 |**master**| - | - |
 |Ubuntu 12.04.5 LTS|![](https://api.travis-ci.org/LateStartStudio/Hero6.svg?branch=master)| Same as Debug|
 |**v0.1.0**| - | - |
-|Ubuntu 12.04.5 LTS|![](https://api.travis-ci.org/LateStartStudio/Hero6.svg?branch=v0.1.0)| Same as Debug|
+|Ubuntu 12.04.5 LTS and OS X 10.11.6 El Capitan|![](https://api.travis-ci.org/LateStartStudio/Hero6.svg?branch=v0.1.0)| Same as Debug|
 
 ###Build Instructions
 Ideally, we want anyone to be able to build Hero6 on any OS with any IDE. This is an ongoing task and we continue our efforts to make that possible. Currently, we can guarantee that it will work on Windows with Visual Studio 2015.

--- a/docs/LICENSE.THIRDPARTY.md
+++ b/docs/LICENSE.THIRDPARTY.md
@@ -12,6 +12,13 @@ Paket is a tool for managing and organizing external projects in form of NuGet p
 * [Repository](https://github.com/fsprojects/Paket)
 * [License](https://github.com/fsprojects/Paket/blob/master/LICENSE.txt)
 
+#### FAKE
+FAKE is a .NET utility tool for building .NET projects with F# scripts and Command-Line Interface, similar to make and makefiles. It is licensed under the Apache v2.0 license.
+
+* [Homepage](http://fsharp.github.io/FAKE/index.html)
+* [Repository](https://github.com/fsharp/FAKE)
+* [License](https://github.com/fsharp/FAKE/blob/master/License.txt)
+
 #### WiX
 WiX is a development kit for creating .msi installers. It is licensed under the MS-RL-license.
 

--- a/src/build.bat
+++ b/src/build.bat
@@ -1,0 +1,19 @@
+REM Build Script
+@ECHO off
+SETLOCAL
+
+CLS
+
+REM Paket
+.paket\paket.bootstrapper.exe
+if errorlevel 1 (
+  exit /b %errorlevel%
+)
+
+.paket\paket.exe restore
+if errorlevel 1 (
+  exit /b %errorlevel%
+)
+
+REM Run FAKE - Default
+packages\FAKE\tools\FAKE.exe

--- a/src/build.fsx
+++ b/src/build.fsx
@@ -1,0 +1,262 @@
+// Includes
+#r @"packages/FAKE/tools/FakeLib.dll"
+
+open System
+open Fake
+open Fake.Testing.NUnit3
+
+type OS = | OSX | Windows | Linux
+
+let getOS =
+        match int Environment.OSVersion.Platform with
+        | 4 | 128 -> Linux
+        | 6       -> OSX
+        | _       -> Windows
+
+// Properties
+let buildDesktopGLDebugConfig = "Debug"
+let buildDesktopGLReleaseConfig = "Release"
+let buildWindowsDXDebugConfig = "WindowsDX Debug"
+let buildWindowsDXReleaseConfig = "WindowsDX Release"
+let buildAndroidDebugConfig = "Android Debug"
+let buildeAndroidReleasConfig = "Android Release"
+
+let buildDesktopGLDebugDir = "../bin/DesktopGL/Debug/"
+let buildDesktopGLReleaseDir = "../bin/DesktopGL/Release/"
+let buildWindowsDXDebugDir = "../bin/WindowsDX/Debug/"
+let buildWindowsDXReleaseDir = "../bin/WindowsDX/Release/"
+let buildAndroidDebugDir = "../bin/Android/Debug/"
+let buildAndroidReleaseDir = "../bin/Android/Release/"
+
+let solutionFile = if getOS = Windows then "./Hero6.Windows.sln" else "./Hero6.Linux.sln"
+
+let isGpuAvailable = not (getEnvironmentVarAsBool "TRAVIS" || getEnvironmentVarAsBool "APPVEYOR")
+
+let build dir config =
+    !! solutionFile
+    |> MSBuild dir "Build"
+        [
+            "Configuration", config
+        ]
+    |> Log ("Her6 Build " + config + " Configuration Output: ")
+
+let testFile dir file =
+    !! (dir + file)
+    |> NUnit3 (fun p ->
+    { p with
+        ToolPath = "packages/NUnit.ConsoleRunner/tools/nunit3-console.exe"
+    })
+
+let testBuild dir =
+    let isGpuAvailable = not (getEnvironmentVarAsBool "TRAVIS" || getEnvironmentVarAsBool "APPVEYOR")
+
+    testFile dir "Collections.Tests.dll"
+    testFile dir "Search.Tests.dll"
+    if isGpuAvailable then
+        testFile dir "Hero6.Tests.dll"
+
+// Targets - Clean
+Target "Clean DesktopGL Debug" (fun _ ->
+    CleanDir buildDesktopGLDebugDir
+)
+
+Target "Clean DesktopGL Release" (fun _ ->
+    CleanDir buildDesktopGLReleaseDir
+)
+
+Target "Clean WindowsDX Debug" (fun _ ->
+    if getOS = Windows then
+        CleanDir buildWindowsDXDebugDir
+    else
+        trace "Skipping Clean - WindowsDX is only supported on Windows"
+)
+
+Target "Clean WindowsDX Release" (fun _ ->
+    if getOS = Windows then
+        CleanDir buildWindowsDXReleaseDir
+    else
+        trace "Skipping Clean - WindowsDX is only supported on Windows"
+)
+
+Target "Clean Android Debug" (fun _ ->
+    if getOS = Windows then
+        CleanDir buildAndroidDebugDir
+    else
+        trace "Skipping Clean - Android is only supported on Windows"
+)
+
+Target "Clean Android Release" (fun _ ->
+    if getOS = Windows then
+        CleanDir buildAndroidReleaseDir
+    else
+        trace "Skipping Clean - Android is only supported on Windows"
+)
+
+// Targets - Build
+Target "Build DesktopGL Debug" (fun _ ->
+    build buildDesktopGLDebugDir buildDesktopGLDebugConfig
+)
+
+Target "Build DesktopGL Release" (fun _ ->
+    build buildDesktopGLReleaseDir buildDesktopGLReleaseConfig
+)
+
+Target "Build WindowsDX Debug" (fun _ ->
+    if getOS = Windows then
+        build buildWindowsDXDebugDir buildWindowsDXDebugConfig
+    else
+        trace "Skipping Build - WindowsDX is only supported on Windows"
+)
+
+Target "Build WindowsDX Release" (fun _ ->
+    if getOS = Windows then
+        build buildWindowsDXReleaseDir buildWindowsDXReleaseConfig
+    else
+        trace "Skipping Build - WindowsDX is only supported on Windows"
+)
+
+Target "Build Android Debug" (fun _ ->
+    if getOS = Windows then
+        build buildAndroidDebugDir buildAndroidDebugConfig
+    else
+        trace "Skipping Build - Android is only supported on Windows"
+)
+
+Target "Build Android Release" (fun _ ->
+    if getOS = Windows then
+        build buildAndroidReleaseDir buildeAndroidReleasConfig
+    else
+        trace "Skipping Build - Android is only supported on Windows"
+)
+
+// Targets - Test
+Target "Test DesktopGL Debug" (fun _ ->
+    testBuild buildDesktopGLDebugDir
+)
+
+Target "Test DesktopGL Release" (fun _ ->
+    testBuild buildDesktopGLDebugDir
+)
+
+Target "Test WindowsDX Debug" (fun _ ->
+    if getOS = Windows then
+        testBuild buildWindowsDXDebugDir
+    else
+        trace "Skipping Test - WindowsDX is only supported on Windows"
+)
+
+Target "Test WindowsDX Release" (fun _ ->
+    if getOS = Windows then
+        testBuild buildWindowsDXReleaseDir
+    else
+        trace "Skipping Test - WindowsDX is only supported on Windows"
+)
+
+Target "Test Android Debug" (fun _ ->
+    trace "Skipping Test - Not supported on config Android"
+)
+
+Target "Test Android Release" (fun _ ->
+    trace "Skipping Test - Not supported on config Android"
+)
+
+// Single Configurations
+Target "DesktopGL Debug" (fun _ ->
+    trace "Completed DesktopGL Debug Build"
+)
+
+Target "DesktopGL Release" (fun _ ->
+    trace "Completed DesktopGL Release Build"
+)
+
+Target "WindowsDX Debug" (fun _ ->
+    trace "Completed WindowsDX Debug Build"
+)
+
+Target "WindowsDX Release" (fun _ ->
+    trace "Completed WindowsDX Release Build"
+)
+
+Target "Android Debug" (fun _ ->
+    trace "Completed Android Debug Build"
+)
+
+Target "Android Release" (fun _ ->
+    trace "Completed Android Release Build"
+)
+
+Target "Default Windows" (fun _ ->
+    trace "Completed Hero6 Build"
+)
+
+Target "Default Linux" (fun _ ->
+    trace "Completed Hero6 Build"
+)
+
+// Dependencies - DesktopGL Debug
+"Clean DesktopGL Debug"
+    ==> "Build DesktopGL Debug"
+    ==> "Test DesktopGL Debug"
+    ==> "DesktopGL Debug"
+
+// Dependencies - DesktopGL Release
+"Clean DesktopGL Release"
+    ==> "Build DesktopGL Release"
+    ==> "Test DesktopGL Release"
+    ==> "DesktopGL Release"
+
+// Dependencies - WindowsDX Debug
+"Clean WindowsDX Debug"
+    ==> "Build WindowsDX Debug"
+    ==> "Test WindowsDX Debug"
+    ==> "WindowsDX Debug"
+
+// Dependencies - WindowsDX Release
+"Clean WindowsDX Release"
+    ==> "Build WindowsDX Release"
+    ==> "Test WindowsDX Release"
+    ==> "WindowsDX Release"
+
+// Dependencies - Android Debug
+"Clean Android Debug"
+    ==> "Build Android Debug"
+    ==> "Test Android Debug"
+    ==> "Android Debug"
+
+// Dependencies - Android Release
+"Clean Android Release"
+    ==> "Build Android Release"
+    ==> "Test Android Release"
+    ==> "Android Release"
+
+// Dependencies - Windows Developer Environment
+"DesktopGL Debug"
+    ==> "Default Windows"
+
+"DesktopGL Release"
+    ==> "Default Windows"
+
+"WindowsDX Debug"
+    ==> "Default Windows"
+
+"WindowsDX Release"
+    ==> "Default Windows"
+
+"Android Debug"
+    ==> "Default Windows"
+
+"Android Release"
+    ==> "Default Windows"
+
+// Dependencies - Linux Developer Environment
+"DesktopGL Debug"
+    ==> "Default Linux"
+
+"DesktopGL Release"
+    ==> "Default Linux"
+
+// Start Build
+if getOS = Windows then
+    RunTargetOrDefault "Default Windows"
+else
+    RunTargetOrDefault "Default Linux"

--- a/src/build.sh
+++ b/src/build.sh
@@ -13,25 +13,5 @@ if [ $exit_code -ne 0 ]; then
   exit $exit_code
 fi
 
-# Compile Build Configs, Debug and Release
-xbuild /p:Configuration=Debug ./Hero6.Linux.sln
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
-  exit $exit_code
-fi
-
-xbuild /p:Configuration=Release ./Hero6.Linux.sln
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
-  exit $exit_code
-fi
-
-# Run Unit Tests
-mono ./packages/NUnit.ConsoleRunner/tools/nunit3-console.exe ./Collections.Tests/bin/Debug/Collections.Tests.dll
-mono ./packages/NUnit.ConsoleRunner/tools/nunit3-console.exe ./Collections.Tests/bin/Release/Collections.Tests.dll
-mono ./packages/NUnit.ConsoleRunner/tools/nunit3-console.exe ./Search.Tests/bin/Debug/Search.Tests.dll
-mono ./packages/NUnit.ConsoleRunner/tools/nunit3-console.exe ./Search.Tests/bin/Release/Search.Tests.dll
-if [ "${TRAVIS_PULL_REQUEST}" = "true" ]; then
-  mono ./packages/NUnit.ConsoleRunner/tools/nunit3-console.exe ./Hero6.DesktopGL.Tests/bin/Debug/Hero6.Tests.dll
-  mono ./packages/NUnit.ConsoleRunner/tools/nunit3-console.exe ./Hero6.DesktopGL.Tests/bin/Release/Hero6.Tests.dll
-fi
+# Run FAKE - Default
+mono ./packages/FAKE/tools/FAKE.exe

--- a/src/paket.dependencies
+++ b/src/paket.dependencies
@@ -2,6 +2,7 @@ source https://nuget.org/api/v2
 
 nuget EmptyKeysUI_Generator
 nuget EmptyKeysUI_MonoGame
+nuget FAKE
 nuget MonoGame.Framework.Android
 nuget MonoGame.Framework.DesktopGL
 nuget MonoGame.Framework.WindowsDX

--- a/src/paket.lock
+++ b/src/paket.lock
@@ -2,6 +2,7 @@ NUGET
   remote: https://www.nuget.org/api/v2
     EmptyKeysUI_Generator (2.6)
     EmptyKeysUI_MonoGame (2.6)
+    FAKE (4.46)
     MonoGame.Framework.Android (3.5.1.1679)
     MonoGame.Framework.DesktopGL (3.5.1.1679)
     MonoGame.Framework.WindowsDX (3.5.1.1679)


### PR DESCRIPTION
Like the title says I have adjusted the Travis config to include OS X and tweaked it so that it works on both Linux and OS X. During this ordeal I decied to add FAKE to the project, by using Common Language Interfacing I can gather all command line build scripts into a single place using batch and shell scripts only as native entry points.

FAKE is completely optional to use, it is helpful for low level CI servers like Travis which rely on scripts or terminal commands for building, but it can also be a useful tool for developers who want to work in text editors like Vim or Emacs instead of dedicated IDEs.