### PR TITLE
Pause game on rendering UI elements like Message Box and Verb Bar

### DIFF
--- a/src/AdventureGame/Campaign.cs
+++ b/src/AdventureGame/Campaign.cs
@@ -206,6 +206,11 @@ namespace LateStartStudio.AdventureGame
         /// <inheritdoc />
         public void Update(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
         {
+            if (this.Engine.IsGamePaused)
+            {
+                return;
+            }
+
             this.CurrentRoom.Update(totalTime, elapsedTime, isRunningSlowly);
         }
 

--- a/src/AdventureGame/Engine/Engine.cs
+++ b/src/AdventureGame/Engine/Engine.cs
@@ -19,6 +19,14 @@ namespace LateStartStudio.AdventureGame.Engine
     public abstract class Engine
     {
         /// <summary>
+        /// Gets or sets a value indicating whether if the game is paused.
+        /// </summary>
+        /// <value>
+        /// A value indicating whether if the game is paused.
+        /// </value>
+        public bool IsGamePaused { get; set; }
+
+        /// <summary>
         /// Gets the graphics handler of the engine.
         /// </summary>
         /// <value>

--- a/src/AdventureGame/UI/UserInterface.cs
+++ b/src/AdventureGame/UI/UserInterface.cs
@@ -103,6 +103,17 @@ namespace LateStartStudio.AdventureGame.UI
             get; set;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether any dialogs are currently visible.
+        /// </summary>
+        /// <value>
+        /// A value indicating whether any dialogs are currently visible.
+        /// </value>
+        protected virtual bool IsDialogVisible
+        {
+            get; set;
+        }
+
         /// <inheritdoc />
         public abstract void Load();
 

--- a/src/Hero6.UserInterface.SierraVga/SierraVgaController.cs
+++ b/src/Hero6.UserInterface.SierraVga/SierraVgaController.cs
@@ -46,6 +46,8 @@ namespace LateStartStudio.Hero6.UserInterface.SierraVga
             ServiceManager.Instance.AddService<ICursorService>(this.mouseCursor);
         }
 
+        protected override bool IsDialogVisible => this.rootViewModel.TextBox.IsVisible;
+
         public override void Load()
         {
             this.defaultFont = this.LoadFont("Arial_11.25_Regular");
@@ -67,9 +69,11 @@ namespace LateStartStudio.Hero6.UserInterface.SierraVga
             SoundManager.Instance.LoadSounds(this.Content.NativeContentManager);
             EffectManager.Instance.LoadEffects(this.Content.NativeContentManager);
 
-            this.rootView.MouseUp += (s, a) => this.rootViewModel.TextBox.Hide();
+            this.rootView.MouseUp += this.OnTextBoxHideOnClick;
             this.rootView.TopBar.MouseEnter += this.OnMouseEnterTopBar;
             this.rootView.VerbBar.MouseLeave += this.OnMouseLeaveVerbBar;
+            this.rootViewModel.TextBox.OnShow += (s, a) => this.AdventureGameEngine.IsGamePaused = true;
+            this.rootViewModel.TextBox.OnHide += (s, a) => this.AdventureGameEngine.IsGamePaused = false;
 
             this.mouseCursor.Load();
         }
@@ -101,8 +105,25 @@ namespace LateStartStudio.Hero6.UserInterface.SierraVga
             return UiEngine.Instance.AssetManager.LoadFont(this.Content.NativeContentManager, $"Fonts/{id}");
         }
 
+        private void OnTextBoxHideOnClick(object sender, MouseButtonEventArgs args)
+        {
+            if (!this.rootViewModel.TextBox.IsVisible)
+            {
+                return;
+            }
+
+            this.rootViewModel.TextBox.Hide();
+            this.AdventureGameEngine.IsGamePaused = false;
+        }
+
         private void OnMouseEnterTopBar(object sender, MouseEventArgs args)
         {
+            if (this.IsDialogVisible)
+            {
+                return;
+            }
+
+            this.AdventureGameEngine.IsGamePaused = true;
             this.mouseCursor.Backup = this.mouseCursor.Current;
             this.rootViewModel.IsVerbBarVisible = true;
             this.rootViewModel.IsTopBarVisible = false;
@@ -110,9 +131,15 @@ namespace LateStartStudio.Hero6.UserInterface.SierraVga
 
         private void OnMouseLeaveVerbBar(object sender, MouseEventArgs args)
         {
+            if (this.IsDialogVisible)
+            {
+                return;
+            }
+
             this.mouseCursor.RestoreFromBackup();
             this.rootViewModel.IsVerbBarVisible = false;
             this.rootViewModel.IsTopBarVisible = true;
+            this.AdventureGameEngine.IsGamePaused = false;
         }
     }
 }

--- a/src/Hero6.UserInterface.SierraVga/ViewModel/TextBoxViewModel.cs
+++ b/src/Hero6.UserInterface.SierraVga/ViewModel/TextBoxViewModel.cs
@@ -27,6 +27,10 @@ namespace LateStartStudio.Hero6.UserInterface.SierraVga.ViewModel
             this.Text = string.Empty;
         }
 
+        public event EventHandler<EventArgs> OnShow;
+
+        public event EventHandler<EventArgs> OnHide;
+
         public string Text
         {
             get { return this.text; }
@@ -59,12 +63,14 @@ namespace LateStartStudio.Hero6.UserInterface.SierraVga.ViewModel
 
             this.Text = input;
             this.IsVisible = true;
+            this.OnShow?.Invoke(this, EventArgs.Empty);
         }
 
         public void Hide()
         {
             this.IsVisible = false;
             this.Text = string.Empty;
+            this.OnHide?.Invoke(this, EventArgs.Empty);
         }
     }
 }


### PR DESCRIPTION
Like title says.

One way of testing this is to make the hero move from point A to point B, and while he's moving, make a UI element like the Verb bar show, the hero should then stop, when the UI is hidden again he should resume movement.