### PR TITLE
#84 Made dummy placeholder logger class for Android platform

### DIFF
--- a/src/Hero6/Game.cs
+++ b/src/Hero6/Game.cs
@@ -55,7 +55,11 @@ namespace LateStartStudio.Hero6
             Logger.Info("Hero6 Game Instance Created.");
         }
 
+#if !ANDROID
         public static ILogger Logger { get; } = new LogFourNet();
+#else
+        public static ILogger Logger { get; } = new DummyLogger();
+#endif
 
         public static string GraphicsApi
         {

--- a/src/Hero6/Hero6.projitems
+++ b/src/Hero6/Hero6.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Game.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IXnaGameLoop.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UserInterface\UserInterfaceHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\DummyLogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ILogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\LogFourNet.cs" />
   </ItemGroup>

--- a/src/Hero6/Utilities/DummyLogger.cs
+++ b/src/Hero6/Utilities/DummyLogger.cs
@@ -1,0 +1,69 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DummyLogger.cs" company="LateStartStudio">
+//   Copyright (C) LateStartStudio
+//   This file is subject to the terms and conditions of the MIT license specified
+//   in the file 'LICENSE.CODE.md', which is a part of this source code package.
+// </copyright>
+// <summary>
+//   Defines the DummyLogger type.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace LateStartStudio.Hero6.Utilities
+{
+    using System;
+
+    /// <summary>
+    /// A dummy logger for platforms where logging is not currently implemented.
+    /// </summary>
+    public class DummyLogger : IDisposable, ILogger
+    {
+        public void Dispose()
+        {
+        }
+
+        public string Filename => "Dummy Logger";
+
+        public bool WillDeleteLogOnDispose { get; set; }
+
+        public void Debug(string message)
+        {
+        }
+
+        public void Debug(string message, Exception e)
+        {
+        }
+
+        public void Info(string message)
+        {
+        }
+
+        public void Info(string message, Exception e)
+        {
+        }
+
+        public void Warning(string message)
+        {
+        }
+
+        public void Warning(string message, Exception e)
+        {
+        }
+
+        public void Error(string message)
+        {
+        }
+
+        public void Error(string message, Exception e)
+        {
+        }
+
+        public void Fatal(string message)
+        {
+        }
+
+        public void Fatal(string message, Exception e)
+        {
+        }
+    }
+}

--- a/src/Hero6/Utilities/LogFourNet.cs
+++ b/src/Hero6/Utilities/LogFourNet.cs
@@ -9,6 +9,7 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+#if !ANDROID
 namespace LateStartStudio.Hero6.Utilities
 {
     using System;
@@ -144,3 +145,4 @@ namespace LateStartStudio.Hero6.Utilities
         }
     }
 }
+#endif


### PR DESCRIPTION
Android platform wouldn't compile because of missing reference to log4net, which wouldn't install by nuget, presumably becaue log4net doesn't offer package for monoandroid??? Either way I don't want to spend more energy than needed working on a platform we may or may not support so I just made a dummy switch to remove log4net references.