### PR TITLE
#92 Fixed size alloction for text boxes

### DIFF
--- a/src/Hero6.UserInterface.SierraVga/ViewModel/TextBoxViewModel.cs
+++ b/src/Hero6.UserInterface.SierraVga/ViewModel/TextBoxViewModel.cs
@@ -68,6 +68,12 @@ namespace LateStartStudio.Hero6.UserInterface.SierraVga.ViewModel
                 this.Height = size.Height * rowCount;
             }
 
+            // Hack: FontManager.DefaultFont.MeasureString doesn't seem to measure all strings
+            // perfectly. Causing UI containers with line breaks to glitch out. So add another
+            // pixel to dimensions for safe measure.
+            this.Width++;
+            this.Height++;
+
             this.Text = input;
             this.IsVisible = true;
             this.OnShow?.Invoke(this, EventArgs.Empty);


### PR DESCRIPTION
EmptyKeys doesn't seem to able to perfectly measure string, add another pixel for safe measure. It's kinda hacky, but as far as hacks go this a pretty safe one.