### PR TITLE
Treat Warnings as errors

### DIFF
--- a/src/AdventureGame/AdventureGame.csproj
+++ b/src/AdventureGame/AdventureGame.csproj
@@ -24,6 +24,7 @@
     <DocumentationFile>bin\Debug\AdventureGame.XML</DocumentationFile>
     <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Collections.Tests/Collections.Tests.csproj
+++ b/src/Collections.Tests/Collections.Tests.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Collections/Collections.csproj
+++ b/src/Collections/Collections.csproj
@@ -24,6 +24,7 @@
     <DocumentationFile>bin\Debug\Collections.XML</DocumentationFile>
     <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Hero6.Android/Hero6.Android.csproj
+++ b/src/Hero6.Android/Hero6.Android.csproj
@@ -35,6 +35,7 @@
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Hero6.Campaigns.RitesOfPassage/Hero6.Campaigns.RitesOfPassage.csproj
+++ b/src/Hero6.Campaigns.RitesOfPassage/Hero6.Campaigns.RitesOfPassage.csproj
@@ -24,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Hero6.DesktopGL.Tests/Hero6.DesktopGL.Tests.csproj
+++ b/src/Hero6.DesktopGL.Tests/Hero6.DesktopGL.Tests.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Hero6.DesktopGL/Hero6.DesktopGL.csproj
+++ b/src/Hero6.DesktopGL/Hero6.DesktopGL.csproj
@@ -27,6 +27,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>

--- a/src/Hero6.UserInterface.SierraVga.Xaml/Hero6.UserInterface.SierraVga.Xaml.csproj
+++ b/src/Hero6.UserInterface.SierraVga.Xaml/Hero6.UserInterface.SierraVga.Xaml.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>5</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Hero6.UserInterface.SierraVga/Hero6.UserInterface.SierraVga.csproj
+++ b/src/Hero6.UserInterface.SierraVga/Hero6.UserInterface.SierraVga.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Hero6.WindowsDX.Tests/Hero6.WindowsDX.Tests.csproj
+++ b/src/Hero6.WindowsDX.Tests/Hero6.WindowsDX.Tests.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Hero6.WindowsDX/Hero6.WindowsDX.csproj
+++ b/src/Hero6.WindowsDX/Hero6.WindowsDX.csproj
@@ -41,6 +41,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>

--- a/src/Search.Tests/Search.Tests.csproj
+++ b/src/Search.Tests/Search.Tests.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Search/Search.csproj
+++ b/src/Search/Search.csproj
@@ -24,6 +24,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Debug\Search.XML</DocumentationFile>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
I set the .csproj property "Treat warnings as errors" to true, for most open-source projects I've seen this is standard practice. The perk to this is obvious, avoid warnings sneaking in on pull requests and have them stacking up on us. It can make coding a little more tedious I guess but in my experience this is not a problem.