### PR TITLE
Compressed Assets

### DIFF
--- a/assets/Hero6.Content.mgcb
+++ b/assets/Hero6.Content.mgcb
@@ -6,7 +6,7 @@
 /platform:DesktopGL
 /config:
 /profile:Reach
-/compress:False
+/compress:True
 
 #-------------------------------- References --------------------------------#
 


### PR DESCRIPTION
I set the MonoGame Content Pipeline Tool to compress the assets on pre-processing. This should result in that the finished product takes significantly less space on disk and possibly memory, on the expense of increased loading time. Although any increased loading time is unlikely to be noticeable on such an old retro style game like this.

Size of Content folder
Before: 2.56 MB
After: 738 KB