### PR TITLE
Removed unconventional unit tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,6 +34,4 @@ build:
 
 test:
   assemblies:
-    - Collections.Tests.dll
-    - Search.Tests.dll
-    - AdventureGame.Tests.dll
+    - '*.Tests.dll'

--- a/src/Hero6.Tests/GameTests.cs
+++ b/src/Hero6.Tests/GameTests.cs
@@ -16,42 +16,5 @@ namespace LateStartStudio.Hero6.Tests
     [TestFixture]
     public class GameTests
     {
-        private Game game;
-
-        [SetUp]
-        public void Init()
-        {
-            this.game = new Game();
-            this.game.RunOneFrame();
-        }
-
-        [TearDown]
-        public void CleanUp()
-        {
-            if (this.game != null)
-            {
-                this.game.Dispose();
-            }
-
-            this.game = null;
-        }
-
-        [Test]
-        public void InitSuccessful()
-        {
-            Assert.Pass();
-        }
-
-        [Test]
-        public void GameIsNotNull()
-        {
-            Assert.IsNotNull(this.game);
-        }
-
-        [Test]
-        public void GraphicsDeviceIsNotNull()
-        {
-            Assert.IsNotNull(this.game.GraphicsDevice);
-        }
     }
 }

--- a/src/build.fsx
+++ b/src/build.fsx
@@ -30,8 +30,6 @@ let buildAndroidReleaseDir = "Hero6.Android/bin/Release/"
 
 let solutionFile = if getOS = Windows then "./Hero6.Windows.sln" else "./Hero6.Linux.sln"
 
-let isGpuAvailable = not (getEnvironmentVarAsBool "TRAVIS" || getEnvironmentVarAsBool "APPVEYOR")
-
 let build dir config =
     !! solutionFile
     |> MSBuild dir "Build"
@@ -47,12 +45,7 @@ let testFile dir file =
         ToolPath = "packages/NUnit.ConsoleRunner/tools/nunit3-console.exe"
     })
 
-let testBuild dir =
-    testFile dir "Collections.Tests.dll"
-    testFile dir "Search.Tests.dll"
-    testFile dir "AdventureGame.Tests.dll"
-    if isGpuAvailable then
-        testFile dir "Hero6.Tests.dll"
+let testBuild dir = testFile dir "*.Tests.dll"
 
 // Targets - Clean
 Target "Clean DesktopGL Debug" (fun _ ->


### PR DESCRIPTION
I removed some unit tests that relied on GPU hardware to initialize. I should never have made these unit tests in the first place, but I fell for the temptation of having tests that checks if the game actually starts. In reality however we had to make ugly special cases for the main game test assembly so it wouldn't run tests on systems missing GPUs, and the tests was to expensive perfomance wise to be integrated into development patterns like TTD or any form where unit tests should be run often.