### PR TITLE
Simplify unit test projects namespaces

### DIFF
--- a/src/AdventureGame.Tests/AdventureGame.Tests.csproj
+++ b/src/AdventureGame.Tests/AdventureGame.Tests.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{5CD0CA14-E1C3-4CDA-9DEA-B22CB116DEAA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LateStartStudio.AdventureGame.Tests</RootNamespace>
+    <RootNamespace>LateStartStudio.AdventureGame</RootNamespace>
     <AssemblyName>AdventureGame.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/AdventureGame.Tests/DummyTests.cs
+++ b/src/AdventureGame.Tests/DummyTests.cs
@@ -1,4 +1,15 @@
-﻿namespace LateStartStudio.AdventureGame.Tests
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DummyTests.cs" company="LateStartStudio">
+//   Copyright (C) LateStartStudio
+//   This file is subject to the terms and conditions of the MIT license specified
+//   in the file 'LICENSE.CODE.md', which is a part of this source code package.
+// </copyright>
+// <summary>
+//   Defines the DummyTests type.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace LateStartStudio.AdventureGame
 {
     using NUnit.Framework;
 

--- a/src/AdventureGame.Tests/Engine/MockContentManager.cs
+++ b/src/AdventureGame.Tests/Engine/MockContentManager.cs
@@ -9,10 +9,9 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.AdventureGame.Tests.Engine
+namespace LateStartStudio.AdventureGame.Engine
 {
-    using AdventureGame.Engine;
-    using AdventureGame.Engine.Graphics;
+    using Graphics;
 
     public class MockContentManager : ContentManager
     {

--- a/src/AdventureGame.Tests/Engine/MockEngine.cs
+++ b/src/AdventureGame.Tests/Engine/MockEngine.cs
@@ -9,10 +9,9 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.AdventureGame.Tests.Engine
+namespace LateStartStudio.AdventureGame.Engine
 {
-    using AdventureGame.Engine;
-    using AdventureGame.Engine.Graphics;
+    using Graphics;
 
     public class MockEngine : Engine
     {

--- a/src/AdventureGame.Tests/MockCampaign.cs
+++ b/src/AdventureGame.Tests/MockCampaign.cs
@@ -9,7 +9,7 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.AdventureGame.Tests
+namespace LateStartStudio.AdventureGame
 {
     using Engine;
     using UI;

--- a/src/AdventureGame.Tests/UI/MockUserInterface.cs
+++ b/src/AdventureGame.Tests/UI/MockUserInterface.cs
@@ -9,12 +9,11 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.AdventureGame.Tests.UI
+namespace LateStartStudio.AdventureGame.UI
 {
     using System;
-    using AdventureGame.Engine;
-    using AdventureGame.Engine.Graphics;
-    using AdventureGame.UI;
+    using Engine;
+    using Engine.Graphics;
 
     public class MockUserInterface : UserInterface
     {

--- a/src/Collections.Tests/Collections.Tests.csproj
+++ b/src/Collections.Tests/Collections.Tests.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{6BEE8AAC-A058-40B2-9009-76416AA682BA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LateStartStudio.Collections.Tests</RootNamespace>
+    <RootNamespace>LateStartStudio.Collections</RootNamespace>
     <AssemblyName>Collections.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/Collections.Tests/Generic/BlueRajaWrapperTests.cs
+++ b/src/Collections.Tests/Generic/BlueRajaWrapperTests.cs
@@ -9,9 +9,8 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.Collections.Tests.Generic
+namespace LateStartStudio.Collections.Generic
 {
-    using Collections.Generic;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/Collections.Tests/Generic/Node.cs
+++ b/src/Collections.Tests/Generic/Node.cs
@@ -9,7 +9,7 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.Collections.Tests.Generic
+namespace LateStartStudio.Collections.Generic
 {
     using Priority_Queue;
 

--- a/src/Collections.Tests/Generic/PriorityQueueTests.cs
+++ b/src/Collections.Tests/Generic/PriorityQueueTests.cs
@@ -9,10 +9,9 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.Collections.Tests.Generic
+namespace LateStartStudio.Collections.Generic
 {
     using System.Collections;
-    using Collections.Generic;
     using NUnit.Framework;
 
     public abstract class PriorityQueueTests

--- a/src/Hero6.DesktopGL.Tests/Hero6.DesktopGL.Tests.csproj
+++ b/src/Hero6.DesktopGL.Tests/Hero6.DesktopGL.Tests.csproj
@@ -6,7 +6,7 @@
     <ProjectGuid>{104B4CAF-4818-45DC-A772-2F5279C73E5A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LateStartStudio.Hero6.Tests</RootNamespace>
+    <RootNamespace>LateStartStudio.Hero6</RootNamespace>
     <AssemblyName>Hero6.Tests</AssemblyName>
     <MonoGamePlatform>DesktopGL</MonoGamePlatform>
     <MonoGameContentBuilderExe Condition=" '$(OS)' != 'Windows_NT' And Exists ('/opt/monogame-pipeline/MGCB.exe') ">/opt/monogame-pipeline/MGCB.exe</MonoGameContentBuilderExe>

--- a/src/Hero6.Tests/GameTests.cs
+++ b/src/Hero6.Tests/GameTests.cs
@@ -9,7 +9,7 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.Hero6.Tests
+namespace LateStartStudio.Hero6
 {
     using NUnit.Framework;
 

--- a/src/Hero6.Tests/Hero6.Tests.projitems
+++ b/src/Hero6.Tests/Hero6.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>b59e1a53-68b3-4d31-8b69-cefc3d5cebb4</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>LateStartStudio.Hero6.Tests</Import_RootNamespace>
+    <Import_RootNamespace>LateStartStudio.Hero6</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)GameTests.cs" />

--- a/src/Hero6.WindowsDX.Tests/Hero6.WindowsDX.Tests.csproj
+++ b/src/Hero6.WindowsDX.Tests/Hero6.WindowsDX.Tests.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{C42A8C34-3145-41B2-B16A-D93D796DB437}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LateStartStudio.Hero6.Tests</RootNamespace>
+    <RootNamespace>LateStartStudio.Hero6</RootNamespace>
     <AssemblyName>Hero6.Tests</AssemblyName>
     <MonoGamePlatform>Windows</MonoGamePlatform>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>

--- a/src/Search.Tests/Pathfinder/AStarTests.cs
+++ b/src/Search.Tests/Pathfinder/AStarTests.cs
@@ -9,10 +9,9 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.Search.Tests.Pathfinder
+namespace LateStartStudio.Search.Pathfinder
 {
     using NUnit.Framework;
-    using Search.Pathfinder;
 
     [TestFixture]
     public class AStarTests : PathfinderTests

--- a/src/Search.Tests/Pathfinder/DijkstraTests.cs
+++ b/src/Search.Tests/Pathfinder/DijkstraTests.cs
@@ -9,10 +9,9 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.Search.Tests.Pathfinder
+namespace LateStartStudio.Search.Pathfinder
 {
     using NUnit.Framework;
-    using Search.Pathfinder;
 
     [TestFixture]
     public class DijkstraTests : PathfinderTests

--- a/src/Search.Tests/Pathfinder/NodeTests.cs
+++ b/src/Search.Tests/Pathfinder/NodeTests.cs
@@ -9,10 +9,9 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.Search.Tests.Pathfinder
+namespace LateStartStudio.Search.Pathfinder
 {
     using NUnit.Framework;
-    using Search.Pathfinder;
 
     [TestFixture]
     public class NodeTests

--- a/src/Search.Tests/Pathfinder/PathfinderTests.cs
+++ b/src/Search.Tests/Pathfinder/PathfinderTests.cs
@@ -9,12 +9,11 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace LateStartStudio.Search.Tests.Pathfinder
+namespace LateStartStudio.Search.Pathfinder
 {
     using System;
     using System.Collections.Generic;
     using NUnit.Framework;
-    using Search.Pathfinder;
 
     [TestFixture]
     public abstract class PathfinderTests

--- a/src/Search.Tests/Search.Tests.csproj
+++ b/src/Search.Tests/Search.Tests.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{18480A92-0609-481E-99AD-6C3346829573}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LateStartStudio.Search.Tests</RootNamespace>
+    <RootNamespace>LateStartStudio.Search</RootNamespace>
     <AssemblyName>Search.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
Removed the "Test" from unit test namespaces as it was plain simpler to reference classes from the same namespace they came from. It was also necessary in the case of shared code that the test project and original projects share the same namespace as code generators would get confused.