### PR TITLE
Disabled Android builds from the FAKE script

### DIFF
--- a/src/build.fsx
+++ b/src/build.fsx
@@ -234,11 +234,12 @@ Target "Default Linux" (fun _ ->
 "WindowsDX Release"
     ==> "Default Windows"
 
-"Android Debug"
-    ==> "Default Windows"
+// Android is not supported or maintained so it is commented out for now
+// "Android Debug"
+//     ==> "Default Windows"
 
-"Android Release"
-    ==> "Default Windows"
+// "Android Release"
+//     ==> "Default Windows"
 
 // Dependencies - Linux Developer Environment
 "DesktopGL Debug"


### PR DESCRIPTION
We do not support or maintain it as stated in the readme