### PR TITLE
Simplify Update and Draw argument list

### DIFF
--- a/src/Hero6.Engine.Tests/UserInterfaces/MockUserInterface.cs
+++ b/src/Hero6.Engine.Tests/UserInterfaces/MockUserInterface.cs
@@ -30,11 +30,11 @@ namespace LateStartStudio.Hero6.Engine.UserInterfaces
         {
         }
 
-        public override void Update(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public override void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
         }
 
-        public override void Draw(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public override void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
         }
 

--- a/src/Hero6.Engine.UserInterfaces.SierraVga/MouseCursor.cs
+++ b/src/Hero6.Engine.UserInterfaces.SierraVga/MouseCursor.cs
@@ -181,22 +181,22 @@ namespace LateStartStudio.Hero6.Engine.UserInterfaces.SierraVga
             throw new NotImplementedException();
         }
 
-        public void Update(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.PreUpdate?.Invoke(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.PreUpdate?.Invoke(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
 
-            this.PostUpdate?.Invoke(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.PostUpdate?.Invoke(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
         }
 
-        public void Draw(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.PreDraw?.Invoke(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.renderer));
+            this.PreDraw?.Invoke(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.renderer));
 
             EmptyKeysRenderer.Begin();
             EmptyKeysRenderer.Draw(this.CurrentTexture, this.Location, this.area, ColorW.White, false);
             EmptyKeysRenderer.End();
 
-            this.PostDraw?.Invoke(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.renderer));
+            this.PostDraw?.Invoke(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.renderer));
         }
 
         private void SetCursor(CursorType cursor, TextureBase texture)

--- a/src/Hero6.Engine.UserInterfaces.SierraVga/SierraVgaController.cs
+++ b/src/Hero6.Engine.UserInterfaces.SierraVga/SierraVgaController.cs
@@ -98,25 +98,25 @@ namespace LateStartStudio.Hero6.Engine.UserInterfaces.SierraVga
             this.InvokePostUnload(this, new UnloadEventArgs());
         }
 
-        public override void Update(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public override void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePreUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
 
-            this.mouseCursor.Update(totalTime, elapsedTime, isRunningSlowly);
-            this.rootView.UpdateInput(elapsedTime.TotalMilliseconds);
-            this.rootView.UpdateLayout(elapsedTime.TotalMilliseconds);
+            this.mouseCursor.Update(total, elapsed, isRunningSlowly);
+            this.rootView.UpdateInput(elapsed.TotalMilliseconds);
+            this.rootView.UpdateLayout(elapsed.TotalMilliseconds);
 
-            this.InvokePostUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePostUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
         }
 
-        public override void Draw(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public override void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, Renderer));
+            this.InvokePreDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, Renderer));
 
-            this.rootView.Draw(elapsedTime.TotalMilliseconds);
-            this.mouseCursor.Draw(totalTime, elapsedTime, isRunningSlowly);
+            this.rootView.Draw(elapsed.TotalMilliseconds);
+            this.mouseCursor.Draw(total, elapsed, isRunningSlowly);
 
-            this.InvokePostDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, Renderer));
+            this.InvokePostDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, Renderer));
         }
 
         public override void ShowTextBox(string text)

--- a/src/Hero6.Engine/Campaigns/AdventureGameElement.cs
+++ b/src/Hero6.Engine/Campaigns/AdventureGameElement.cs
@@ -136,10 +136,10 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         public abstract void Unload();
 
         /// <inheritdoc />
-        public abstract void Update(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly);
+        public abstract void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly);
 
         /// <inheritdoc />
-        public abstract void Draw(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly);
+        public abstract void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly);
 
         /// <summary>
         /// Shows a box with the input text.

--- a/src/Hero6.Engine/Campaigns/Campaign.cs
+++ b/src/Hero6.Engine/Campaigns/Campaign.cs
@@ -270,28 +270,28 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         }
 
         /// <inheritdoc />
-        public void Update(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.PreUpdate?.Invoke(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.PreUpdate?.Invoke(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
 
             if (IsPaused)
             {
                 return;
             }
 
-            this.CurrentRoom.Update(totalTime, elapsedTime, isRunningSlowly);
+            this.CurrentRoom.Update(total, elapsed, isRunningSlowly);
 
-            this.PostUpdate?.Invoke(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.PostUpdate?.Invoke(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
         }
 
         /// <inheritdoc />
-        public void Draw(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.PreDraw?.Invoke(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, Renderer));
+            this.PreDraw?.Invoke(this, new DrawEventArgs(total, elapsed, isRunningSlowly, Renderer));
 
-            this.CurrentRoom.Draw(totalTime, elapsedTime, isRunningSlowly);
+            this.CurrentRoom.Draw(total, elapsed, isRunningSlowly);
 
-            this.PostDraw?.Invoke(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, Renderer));
+            this.PostDraw?.Invoke(this, new DrawEventArgs(total, elapsed, isRunningSlowly, Renderer));
         }
 
         /// <summary>

--- a/src/Hero6.Engine/Campaigns/Character.cs
+++ b/src/Hero6.Engine/Campaigns/Character.cs
@@ -228,35 +228,29 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         }
 
         /// <inheritdoc />
-        public override sealed void Update(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public override sealed void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePreUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
 
             this.Animation.IsMoving = this.MovementPath.Count > 0;
 
             this.MoveCharacter();
-            this.Animation.Update(totalTime, elapsedTime, isRunningSlowly);
+            this.Animation.Update(total, elapsed, isRunningSlowly);
 
-            this.InvokePostUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePostUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
         }
 
         /// <inheritdoc />
-        public override sealed void Draw(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public override sealed void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.Campaign.Renderer));
+            this.InvokePreDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.Campaign.Renderer));
 
             if (this.IsVisible)
             {
-                this.Animation.Draw(totalTime, elapsedTime, isRunningSlowly);
+                this.Animation.Draw(total, elapsed, isRunningSlowly);
             }
 
-            this.InvokePostDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.Campaign.Renderer));
+            this.InvokePostDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.Campaign.Renderer));
         }
 
         private void MoveCharacter()

--- a/src/Hero6.Engine/Campaigns/CharacterAnimation.cs
+++ b/src/Hero6.Engine/Campaigns/CharacterAnimation.cs
@@ -216,16 +216,13 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         }
 
         /// <inheritdoc />
-        public override sealed void Update(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public override sealed void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePreUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
 
             if (this.IsMoving)
             {
-                this.elapsedTime += (float)totalTime.TotalSeconds;
+                this.elapsedTime += (float)total.TotalSeconds;
 
                 if (this.elapsedTime < (float)1 / 16)
                 {
@@ -245,16 +242,13 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
                 this.currentFrame = 0;
             }
 
-            this.InvokePostUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePostUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
         }
 
         /// <inheritdoc />
-        public override sealed void Draw(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public override sealed void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.Campaign.Renderer));
+            this.InvokePreDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.Campaign.Renderer));
 
             Rectangle destRectangle = new Rectangle(
                 this.Location.X,
@@ -270,7 +264,7 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
 
             this.Campaign.Renderer.Draw(this.CurrentSprite.Sheet, destRectangle, sourceRectangle, Color.White);
 
-            this.InvokePostDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.Campaign.Renderer));
+            this.InvokePostDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.Campaign.Renderer));
         }
 
         private void ChangeCurrentSprite(Vector2 direction)

--- a/src/Hero6.Engine/Campaigns/InventoryItem.cs
+++ b/src/Hero6.Engine/Campaigns/InventoryItem.cs
@@ -63,19 +63,13 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         }
 
         /// <inheritdoc />
-        public override void Update(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public override void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public override void Draw(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public override void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
             throw new NotImplementedException();
         }

--- a/src/Hero6.Engine/Campaigns/Item.cs
+++ b/src/Hero6.Engine/Campaigns/Item.cs
@@ -113,30 +113,24 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         }
 
         /// <inheritdoc />
-        public override sealed void Update(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public override sealed void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePreUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
 
-            this.InvokePostUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePostUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
         }
 
         /// <inheritdoc />
-        public override sealed void Draw(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public override sealed void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.Campaign.Renderer));
+            this.InvokePreDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.Campaign.Renderer));
 
             if (this.IsVisible)
             {
                 Campaign.Renderer.Draw(this.sprite, this.Location);
             }
 
-            this.InvokePostDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.Campaign.Renderer));
+            this.InvokePostDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.Campaign.Renderer));
         }
     }
 }

--- a/src/Hero6.Engine/Campaigns/Room.cs
+++ b/src/Hero6.Engine/Campaigns/Room.cs
@@ -177,36 +177,30 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         }
 
         /// <inheritdoc />
-        public sealed override void Update(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public sealed override void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePreUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
 
             foreach (Item item in this.Items)
             {
-                item.Update(totalTime, elapsedTime, isRunningSlowly);
+                item.Update(total, elapsed, isRunningSlowly);
             }
 
             foreach (Character character in this.Characters)
             {
-                character.Update(totalTime, elapsedTime, isRunningSlowly);
+                character.Update(total, elapsed, isRunningSlowly);
             }
 
             Color pixel = this.hotspotMaskBuffer[this.Campaign.Player.Location.Y, this.Campaign.Player.Location.X];
             this.Hotspots[pixel].InvokeWhileStandingIn(new HotspotWalkingEventArgs(Campaign.Player));
 
-            this.InvokePostUpdate(this, new UpdateEventArgs(totalTime, elapsedTime, isRunningSlowly));
+            this.InvokePostUpdate(this, new UpdateEventArgs(total, elapsed, isRunningSlowly));
         }
 
         /// <inheritdoc />
-        public sealed override void Draw(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly)
+        public sealed override void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.InvokePreDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.Campaign.Renderer));
+            this.InvokePreDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.Campaign.Renderer));
 
             if (this.IsVisible)
             {
@@ -215,15 +209,15 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
 
             foreach (Item item in this.Items)
             {
-                item.Draw(totalTime, elapsedTime, isRunningSlowly);
+                item.Draw(total, elapsed, isRunningSlowly);
             }
 
             foreach (Character character in this.Characters)
             {
-                character.Draw(totalTime, elapsedTime, isRunningSlowly);
+                character.Draw(total, elapsed, isRunningSlowly);
             }
 
-            this.InvokePostDraw(this, new DrawEventArgs(totalTime, elapsedTime, isRunningSlowly, this.Campaign.Renderer));
+            this.InvokePostDraw(this, new DrawEventArgs(total, elapsed, isRunningSlowly, this.Campaign.Renderer));
         }
 
         /// <summary>

--- a/src/Hero6.Engine/Campaigns/SpriteSheet.cs
+++ b/src/Hero6.Engine/Campaigns/SpriteSheet.cs
@@ -150,13 +150,13 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         }
 
         /// <inheritdoc />
-        public void Update(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public void Draw(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
             throw new NotImplementedException();
         }

--- a/src/Hero6.Engine/GameLoop/DrawEventArgs.cs
+++ b/src/Hero6.Engine/GameLoop/DrawEventArgs.cs
@@ -22,16 +22,16 @@ namespace LateStartStudio.Hero6.Engine.GameLoop
         /// <summary>
         /// Initializes a new instance of the <see cref="DrawEventArgs"/> class.
         /// </summary>
-        /// <param name="totalTime">The total time span since first update loop.</param>
-        /// <param name="elapsedTime">The time span since previous update loop.</param>
+        /// <param name="total">The total time span since first update loop.</param>
+        /// <param name="elapsed">The time span since previous update loop.</param>
         /// <param name="isRunningSlowly">
         /// A value indicating whether game is running slowly, true if it is, false if else.
         /// </param>
         /// <param name="renderer">The graphics handler.</param>
-        public DrawEventArgs(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly, Renderer renderer)
+        public DrawEventArgs(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly, Renderer renderer)
         {
-            this.TotalTime = totalTime;
-            this.ElapsedTime = elapsedTime;
+            this.TotalTime = total;
+            this.ElapsedTime = elapsed;
             this.IsRunningSlowly = isRunningSlowly;
             this.Renderer = renderer;
         }

--- a/src/Hero6.Engine/GameLoop/IGameLoop.cs
+++ b/src/Hero6.Engine/GameLoop/IGameLoop.cs
@@ -71,25 +71,25 @@ namespace LateStartStudio.Hero6.Engine.GameLoop
         /// <summary>
         /// Updates game logic.
         /// </summary>
-        /// <param name="totalTime">The amount of game time since the start of the game.</param>
-        /// <param name="elapsedTime">
+        /// <param name="total">The amount of game time since the start of the game.</param>
+        /// <param name="elapsed">
         /// The amount of elapsed game time since the last update.
         /// </param>
         /// <param name="isRunningSlowly">
         /// Whether the game is running multiple updates this frame.
         /// </param>
-        void Update(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly);
+        void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly);
 
         /// <summary>
         /// Draws the game to the screen.
         /// </summary>
-        /// <param name="totalTime">The amount of game time since the start of the game.</param>
-        /// <param name="elapsedTime">
+        /// <param name="total">The amount of game time since the start of the game.</param>
+        /// <param name="elapsed">
         /// The amount of elapsed game time since the last update.
         /// </param>
         /// <param name="isRunningSlowly">
         /// Whether the game is running multiple updates this frame.
         /// </param>
-        void Draw(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly);
+        void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly);
     }
 }

--- a/src/Hero6.Engine/GameLoop/UpdateEventArgs.cs
+++ b/src/Hero6.Engine/GameLoop/UpdateEventArgs.cs
@@ -21,15 +21,15 @@ namespace LateStartStudio.Hero6.Engine.GameLoop
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdateEventArgs"/> class.
         /// </summary>
-        /// <param name="totalTime">The total time span since first update loop.</param>
-        /// <param name="elapsedTime">The time span since previous update loop.</param>
+        /// <param name="total">The total time span since first update loop.</param>
+        /// <param name="elapsed">The time span since previous update loop.</param>
         /// <param name="isRunningSlowly">
         /// A value indicating whether game is running slowly, true if it is, false if else.
         /// </param>
-        public UpdateEventArgs(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly)
+        public UpdateEventArgs(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly)
         {
-            this.TotalTime = totalTime;
-            this.ElapsedTime = elapsedTime;
+            this.TotalTime = total;
+            this.ElapsedTime = elapsed;
             this.IsRunningSlowly = isRunningSlowly;
         }
 

--- a/src/Hero6.Engine/UserInterfaces/UserInterface.cs
+++ b/src/Hero6.Engine/UserInterfaces/UserInterface.cs
@@ -148,13 +148,10 @@ namespace LateStartStudio.Hero6.Engine.UserInterfaces
         public abstract void Unload();
 
         /// <inheritdoc />
-        public abstract void Update(
-            TimeSpan totalTime,
-            TimeSpan elapsedTime,
-            bool isRunningSlowly);
+        public abstract void Update(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly);
 
         /// <inheritdoc />
-        public abstract void Draw(TimeSpan totalTime, TimeSpan elapsedTime, bool isRunningSlowly);
+        public abstract void Draw(TimeSpan total, TimeSpan elapsed, bool isRunningSlowly);
 
         /// <summary>
         /// Shows a text box with the input text.

--- a/src/Hero6/Engine/Campaigns/CampaignHandler.cs
+++ b/src/Hero6/Engine/Campaigns/CampaignHandler.cs
@@ -58,20 +58,14 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
             this.CurrentCampaign.Unload();
         }
 
-        public void Update(GameTime gameTime)
+        public void Update(GameTime time)
         {
-            this.CurrentCampaign.Update(
-                gameTime.ElapsedGameTime,
-                gameTime.TotalGameTime,
-                gameTime.IsRunningSlowly);
+            this.CurrentCampaign.Update(time.ElapsedGameTime, time.TotalGameTime, time.IsRunningSlowly);
         }
 
-        public void Draw(GameTime gameTime, SpriteBatch spriteBatch)
+        public void Draw(GameTime time, SpriteBatch spriteBatch)
         {
-            this.CurrentCampaign.Draw(
-                gameTime.ElapsedGameTime,
-                gameTime.TotalGameTime,
-                gameTime.IsRunningSlowly);
+            this.CurrentCampaign.Draw(time.ElapsedGameTime, time.TotalGameTime, time.IsRunningSlowly);
         }
     }
 }

--- a/src/Hero6/Engine/UserInterfaces/UserInterfaceHandler.cs
+++ b/src/Hero6/Engine/UserInterfaces/UserInterfaceHandler.cs
@@ -87,20 +87,14 @@ namespace LateStartStudio.Hero6.Engine.UserInterfaces
             this.CurrentUI.Unload();
         }
 
-        public void Update(GameTime gameTime)
+        public void Update(GameTime time)
         {
-            this.CurrentUI.Update(
-                gameTime.TotalGameTime,
-                gameTime.ElapsedGameTime,
-                gameTime.IsRunningSlowly);
+            this.CurrentUI.Update(time.TotalGameTime, time.ElapsedGameTime, time.IsRunningSlowly);
         }
 
-        public void Draw(GameTime gameTime, SpriteBatch spriteBatch)
+        public void Draw(GameTime time, SpriteBatch spriteBatch)
         {
-            this.CurrentUI.Draw(
-                gameTime.TotalGameTime,
-                gameTime.ElapsedGameTime,
-                gameTime.IsRunningSlowly);
+            this.CurrentUI.Draw(time.TotalGameTime, time.ElapsedGameTime, time.IsRunningSlowly);
         }
     }
 }

--- a/src/Hero6/Game.cs
+++ b/src/Hero6/Game.cs
@@ -175,20 +175,20 @@ namespace LateStartStudio.Hero6
         /// Allows the game to run logic such as updating the world,
         /// checking for collisions, gathering input, and playing audio.
         /// </summary>
-        /// <param name="gameTime">Provides a snapshot of timing values.</param>
-        protected override void Update(GameTime gameTime)
+        /// <param name="time">Provides a snapshot of timing values.</param>
+        protected override void Update(GameTime time)
         {
-            this.ui.Update(gameTime);
-            this.campaign.Update(gameTime);
+            this.ui.Update(time);
+            this.campaign.Update(time);
 
-            base.Update(gameTime);
+            base.Update(time);
         }
 
         /// <summary>
         /// This is called when the game should draw itself.
         /// </summary>
-        /// <param name="gameTime">Provides a snapshot of timing values.</param>
-        protected override void Draw(GameTime gameTime)
+        /// <param name="time">Provides a snapshot of timing values.</param>
+        protected override void Draw(GameTime time)
         {
             GraphicsDevice.Clear(Color.Transparent);
 
@@ -201,14 +201,14 @@ namespace LateStartStudio.Hero6
                 null,
                 Transform);
 
-            this.campaign.Draw(gameTime, this.spriteBatch);
+            this.campaign.Draw(time, this.spriteBatch);
 
             this.spriteBatch.End();
 
             // Independent draw
-            this.ui.Draw(gameTime, this.spriteBatch);
+            this.ui.Draw(time, this.spriteBatch);
 
-            base.Draw(gameTime);
+            base.Draw(time);
         }
 
         private void SetScale()

--- a/src/Hero6/IXnaGameLoop.cs
+++ b/src/Hero6/IXnaGameLoop.cs
@@ -22,8 +22,8 @@ namespace LateStartStudio.Hero6
 
         void Unload();
 
-        void Update(GameTime gameTime);
+        void Update(GameTime time);
 
-        void Draw(GameTime gameTime, SpriteBatch spriteBatch);
+        void Draw(GameTime time, SpriteBatch spriteBatch);
     }
 }


### PR DESCRIPTION
This fixes a small annoyance I've had for a long time with the Update and Draw function calls. The line with the function name and arguments is so long I end up breaking it over multiple lines, however by simplifying some of the argument names(removing time from gameTime argument name) I can put the Update and Draw function to a single line, which is much nicer.