### PR TITLE
Organized build scripts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,18 +15,7 @@ configuration:
   #- Android Release
 
 install:
-  # MonoGame
-  - ps: (new-object net.webclient).DownloadFile('http://www.monogame.net/releases/v3.5.1/MonoGameSetup.exe', 'C:\MonoGameSetup.exe')
-  - ps: Invoke-Command -ScriptBlock {C:\MonoGameSetup.exe /S /v/qn}
-
-  # Advanced Installer
-  - ps: (new-object net.webclient).DownloadFile('http://www.advancedinstaller.com/downloads/advinst.msi', 'C:\advinst.msi')
-  - ps: Invoke-Command -ScriptBlock {msiexec.exe /i C:\advinst.msi /qn}
-
-  # Paket
-  - cmd: cd src
-  - cmd: .paket\paket.bootstrapper.exe
-  - cmd: .paket\paket.exe restore
+    - ps: src\.ci\install.ps1
 
 build:
   parallel: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@
 
 language: csharp
 
+sudo: required
+
 notifications:
   email: false
 
@@ -16,45 +18,10 @@ os:
   - linux
   - osx
 
-before_install:
-  - >
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]];
-    then
-      # git-lfs
-      mkdir -p $HOME/bin;
-      wget https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz;
-      tar xvfz git-lfs-linux-amd64-1.1.2.tar.gz;
-      mv git-lfs-1.1.2/git-lfs $HOME/bin/git-lfs;
-      export PATH=$PATH:$HOME/bin/;
+before_install: ./src/.ci/before_install.${TRAVIS_OS_NAME}.sh
 
-      # MonoGame
-      wget http://www.monogame.net/releases/v3.4/MonoGame.Linux.zip;
-      unzip ./MonoGame.Linux.zip;
-    else
-      # git-lfs
-      brew update && brew install git-lfs;
+install: ./src/.ci/install.${TRAVIS_OS_NAME}.sh
 
-      # MonoGame
-      wget http://www.monogame.net/releases/v3.4/MonoGame.MacOS.pkg;
-    fi;
+before_script: ./src/.ci/before_script.${TRAVIS_OS_NAME}.sh
 
-  - find * -type f -exec chmod 777 {} \;
-
-install:
-  - >
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]];
-    then
-      sudo ./generate.sh;
-      yes y | sudo ./monogame-linux.run;
-    else
-      sudo installer -allowUntrusted -verboseR -pkg ./MonoGame.MacOS.pkg -target /;
-    fi;
-
-  - git lfs install
-
-before_script:
-  - git lfs pull
-
-script:
-  - cd src
-  - ./build.sh
+script: ./src/.ci/script.${TRAVIS_OS_NAME}.sh

--- a/src/.ci/Readme.md
+++ b/src/.ci/Readme.md
@@ -1,0 +1,2 @@
+# .CI Readme
+All contents in this folder are scripts intended to be used with Continuous Integration (CI) systems like Travis and Appveyor. Any script contained within these folders should not be used on private home computers, unless you know exactly what you are doing.

--- a/src/.ci/before_install.linux.sh
+++ b/src/.ci/before_install.linux.sh
@@ -1,0 +1,12 @@
+# git-lfs
+mkdir -p $HOME/bin;
+wget https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz;
+tar xvfz git-lfs-linux-amd64-1.1.2.tar.gz;
+mv git-lfs-1.1.2/git-lfs $HOME/bin/git-lfs;
+export PATH=$PATH:$HOME/bin/;
+
+# MonoGame
+wget http://www.monogame.net/releases/v3.4/MonoGame.Linux.zip;
+unzip ./MonoGame.Linux.zip;
+
+find * -type f -exec chmod 777 {} \;

--- a/src/.ci/before_install.osx.sh
+++ b/src/.ci/before_install.osx.sh
@@ -1,0 +1,5 @@
+# git-lfs
+brew update && brew install git-lfs;
+
+# MonoGame
+wget http://www.monogame.net/releases/v3.4/MonoGame.MacOS.pkg;

--- a/src/.ci/before_script.linux.sh
+++ b/src/.ci/before_script.linux.sh
@@ -1,0 +1,1 @@
+git lfs pull

--- a/src/.ci/before_script.osx.sh
+++ b/src/.ci/before_script.osx.sh
@@ -1,0 +1,1 @@
+git lfs pull

--- a/src/.ci/install.linux.sh
+++ b/src/.ci/install.linux.sh
@@ -1,0 +1,6 @@
+#git-lfs
+git lfs install
+
+#MonoGame
+sudo ./generate.sh;
+yes y | sudo ./monogame-linux.run;

--- a/src/.ci/install.osx.sh
+++ b/src/.ci/install.osx.sh
@@ -1,0 +1,5 @@
+#git-lfs
+git lfs install
+
+#MonoGame
+sudo installer -allowUntrusted -verboseR -pkg ./MonoGame.MacOS.pkg -target /;

--- a/src/.ci/install.ps1
+++ b/src/.ci/install.ps1
@@ -1,0 +1,13 @@
+# MonoGame
+(new-object net.webclient).DownloadFile('http://www.monogame.net/releases/v3.5.1/MonoGameSetup.exe', 'C:\MonoGameSetup.exe')
+Invoke-Command -ScriptBlock {C:\MonoGameSetup.exe /S /v/qn}
+
+# Advanced Installer
+(new-object net.webclient).DownloadFile('http://www.advancedinstaller.com/downloads/advinst.msi', 'C:\advinst.msi')
+Invoke-Command -ScriptBlock {msiexec.exe /i C:\advinst.msi /qn}
+
+# Paket
+cd src
+Start-Process -FilePath ".paket\paket.bootstrapper.exe" -NoNewWindow -Wait
+Start-Process -FilePath ".paket\paket.exe" -ArgumentList "restore" -NoNewWindow -Wait
+cd ..

--- a/src/.ci/script.linux.sh
+++ b/src/.ci/script.linux.sh
@@ -1,0 +1,3 @@
+cd src
+./paket.sh
+./build.sh

--- a/src/.ci/script.osx.sh
+++ b/src/.ci/script.osx.sh
@@ -1,0 +1,3 @@
+cd src
+./paket.sh
+./build.sh

--- a/src/build.bat
+++ b/src/build.bat
@@ -3,14 +3,4 @@ SETLOCAL
 
 CLS
 
-.paket\paket.bootstrapper.exe
-if errorlevel 1 (
-  exit /b %errorlevel%
-)
-
-.paket\paket.exe restore
-if errorlevel 1 (
-  exit /b %errorlevel%
-)
-
 packages\FAKE\tools\FAKE.exe

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,17 +1,4 @@
 # Build Script
 
-# Paket
-mono ./.paket/paket.bootstrapper.exe
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
-  exit $exit_code
-fi
-
-mono ./.paket/paket.exe restore
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
-  exit $exit_code
-fi
-
 # Run FAKE - Default
 mono ./packages/FAKE/tools/FAKE.exe

--- a/src/paket.bat
+++ b/src/paket.bat
@@ -1,0 +1,16 @@
+@ECHO off
+SETLOCAL
+
+CLS
+
+if not exist ".paket\paket.exe" (
+  .paket\paket.bootstrapper.exe
+  if errorlevel 1 (
+    exit /b %errorlevel%
+  )
+)
+
+.paket\paket.exe restore
+if errorlevel 1 (
+  exit /b %errorlevel%
+)

--- a/src/paket.sh
+++ b/src/paket.sh
@@ -1,0 +1,14 @@
+#Paket Script
+if [ ! -f "./.paket/paket.exe" ]; then
+  mono ./.paket/paket.bootstrapper.exe
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+    exit $exit_code
+  fi
+fi
+
+mono ./.paket/paket.exe restore
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+  exit $exit_code
+fi


### PR DESCRIPTION
- Cleaned up Travis build steps by adding each step in separate scripts, invoking platform specific script by environment variable.
- Cleaned up Appveyor script by moving install step to Powershell script.
- Moved paket package restoration to a separate script
- Paket script will now only run bootstrapper if paket.exe doesn't already exist