### PR TITLE
Changed campaign module platform

### DIFF
--- a/src/Hero6.Engine.Campaigns.RitesOfPassage/Hero6.Engine.Campaigns.RitesOfPassage.csproj
+++ b/src/Hero6.Engine.Campaigns.RitesOfPassage/Hero6.Engine.Campaigns.RitesOfPassage.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{DE807934-27EC-43A8-831F-15371284F11F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>


### PR DESCRIPTION
It had a x86 platform, however there's no reason for it to have that so it was replaced with AnyCPU