### PR TITLE
Fixed wrong insertion of TimeSpan arguments

### DIFF
--- a/src/Hero6.Engine/Campaigns/CharacterAnimation.cs
+++ b/src/Hero6.Engine/Campaigns/CharacterAnimation.cs
@@ -217,7 +217,7 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
 
             if (this.IsMoving)
             {
-                this.elapsedTime += (float)total.TotalSeconds;
+                this.elapsedTime += (float)elapsed.TotalSeconds;
 
                 if (this.elapsedTime < (float)1 / 16)
                 {

--- a/src/Hero6/Engine/Campaigns/CampaignHandler.cs
+++ b/src/Hero6/Engine/Campaigns/CampaignHandler.cs
@@ -54,12 +54,12 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
 
         public void Update(GameTime time)
         {
-            this.CurrentCampaign.Update(time.ElapsedGameTime, time.TotalGameTime, time.IsRunningSlowly);
+            this.CurrentCampaign.Update(time.TotalGameTime, time.ElapsedGameTime, time.IsRunningSlowly);
         }
 
         public void Draw(GameTime time, SpriteBatch spriteBatch)
         {
-            this.CurrentCampaign.Draw(time.ElapsedGameTime, time.TotalGameTime, time.IsRunningSlowly);
+            this.CurrentCampaign.Draw(time.TotalGameTime, time.ElapsedGameTime, time.IsRunningSlowly);
         }
     }
 }


### PR DESCRIPTION
In the campaign handler the total and elapsed timespan arguments was switched which resulted in head scratching debugging whenever I have to work with frame independent logic.