### PR TITLE
Changed renderer property in Campaign to static

### DIFF
--- a/src/Hero6.Engine.Campaigns.RitesOfPassage/RitesOfPassage.cs
+++ b/src/Hero6.Engine.Campaigns.RitesOfPassage/RitesOfPassage.cs
@@ -15,8 +15,8 @@ namespace LateStartStudio.Hero6.Engine.Campaigns.RitesOfPassage
 
     public sealed class RitesOfPassage : Campaign
     {
-        public RitesOfPassage(Renderer renderer, AssetManager assets, UserInterface userInterface)
-            : base("Rites of Passage", 100, renderer, assets, userInterface)
+        public RitesOfPassage(AssetManager assets, UserInterface userInterface)
+            : base("Rites of Passage", 100, assets, userInterface)
         {
             this.AddCharacters();
             this.AddItems();

--- a/src/Hero6.Engine.Tests/Campaigns/MockCampaign.cs
+++ b/src/Hero6.Engine.Tests/Campaigns/MockCampaign.cs
@@ -16,8 +16,8 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
 
         private static MockCampaign instance;
 
-        private MockCampaign(Renderer renderer, MockAssetManager assets, MockUserInterface ui)
-            : base(Id, Cap, renderer, assets, ui)
+        private MockCampaign(MockAssetManager assets, MockUserInterface ui)
+            : base(Id, Cap, assets, ui)
         {
         }
 
@@ -27,11 +27,11 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
             {
                 if (instance == null)
                 {
-                    MockRenderer renderer = new MockRenderer();
+                    Campaign.Renderer = new MockRenderer();
                     MockAssetManager assets = new MockAssetManager();
                     MockUserInterface ui = new MockUserInterface(assets, null);
 
-                    instance = new MockCampaign(renderer, assets, ui);
+                    instance = new MockCampaign(assets, ui);
                 }
 
                 return instance;

--- a/src/Hero6.Engine.Tests/GameLoop/DrawEventArgsTests.cs
+++ b/src/Hero6.Engine.Tests/GameLoop/DrawEventArgsTests.cs
@@ -17,34 +17,34 @@ namespace LateStartStudio.Hero6.Engine.GameLoop
         [Test]
         public void IsNotNull()
         {
-            Assert.IsNotNull(new DrawEventArgs(TimeSpan.Zero, TimeSpan.Zero, false, MockCampaign.Instance.Renderer));
+            Assert.IsNotNull(new DrawEventArgs(TimeSpan.Zero, TimeSpan.Zero, false, Campaign.Renderer));
         }
 
         [Test]
         public void TotalTimeGet()
         {
             TimeSpan expected = TimeSpan.FromHours(4);
-            Assert.AreEqual(expected, new DrawEventArgs(expected, TimeSpan.Zero, false, MockCampaign.Instance.Renderer).TotalTime);
+            Assert.AreEqual(expected, new DrawEventArgs(expected, TimeSpan.Zero, false, Campaign.Renderer).TotalTime);
         }
 
         [Test]
         public void ElapsedTimeGet()
         {
             TimeSpan expected = TimeSpan.FromHours(4);
-            Assert.AreEqual(expected, new DrawEventArgs(TimeSpan.Zero, expected, false, MockCampaign.Instance.Renderer).ElapsedTime);
+            Assert.AreEqual(expected, new DrawEventArgs(TimeSpan.Zero, expected, false, Campaign.Renderer).ElapsedTime);
         }
 
         [Test]
         public void IsRunningSlowlyGet()
         {
             const bool Expected = false;
-            Assert.AreEqual(Expected, new DrawEventArgs(TimeSpan.Zero, TimeSpan.Zero, Expected, MockCampaign.Instance.Renderer).IsRunningSlowly);
+            Assert.AreEqual(Expected, new DrawEventArgs(TimeSpan.Zero, TimeSpan.Zero, Expected, Campaign.Renderer).IsRunningSlowly);
         }
 
         [Test]
         public void EngineGet()
         {
-            Renderer expected = MockCampaign.Instance.Renderer;
+            Renderer expected = Campaign.Renderer;
             Assert.AreEqual(expected, new DrawEventArgs(TimeSpan.Zero, TimeSpan.Zero, false, expected).Renderer);
         }
     }

--- a/src/Hero6.Engine/Campaigns/Campaign.cs
+++ b/src/Hero6.Engine/Campaigns/Campaign.cs
@@ -29,21 +29,14 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         /// </summary>
         /// <param name="name">The name of the campaign.</param>
         /// <param name="statCap">The stat cap of this campaign instance.</param>
-        /// <param name="renderer">The engine that will run the campaign.</param>
         /// <param name="assets">The assets manager that will load campaign assets.</param>
         /// <param name="userInterface">The user interface that this campaign will use.</param>
-        protected Campaign(
-            string name,
-            int statCap,
-            Renderer renderer,
-            AssetManager assets,
-            UserInterface userInterface)
+        protected Campaign(string name, int statCap, AssetManager assets, UserInterface userInterface)
         {
             Util.Logger?.Info($"Creating Campaign instance. - {name}");
 
             this.Name = name;
             this.StatCap = statCap;
-            this.Renderer = renderer;
             this.Assets = assets;
 
             this.UserInterface = userInterface;
@@ -82,6 +75,11 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         public event EventHandler<DrawEventArgs> PostDraw;
 
         /// <summary>
+        /// Gets or sets the renderer of the campaign.
+        /// </summary>
+        public static Renderer Renderer { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the campaign is paused or not.
         /// </summary>
         /// <value>
@@ -108,14 +106,6 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         /// The stat cap of this campaign instance.
         /// </value>
         public int StatCap { get; }
-
-        /// <summary>
-        /// Gets the engine of the campaign.
-        /// </summary>
-        /// <value>
-        /// The engine of the campaign.
-        /// </value>
-        public Renderer Renderer { get; }
 
         /// <summary>
         /// Gets the <see cref="AssetManager"/> of the <see cref="Campaign"/> instance.

--- a/src/Hero6.Engine/Campaigns/CharacterAnimation.cs
+++ b/src/Hero6.Engine/Campaigns/CharacterAnimation.cs
@@ -247,7 +247,7 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
                 this.Width,
                 this.Height);
 
-            this.Campaign.Renderer.Draw(this.CurrentSprite.Sheet, destRectangle, sourceRectangle, Color.White);
+            Campaign.Renderer.Draw(this.CurrentSprite.Sheet, destRectangle, sourceRectangle, Color.White);
         }
 
         private void ChangeCurrentSprite(Vector2 direction)

--- a/src/Hero6.Engine/Campaigns/Room.cs
+++ b/src/Hero6.Engine/Campaigns/Room.cs
@@ -191,7 +191,7 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         {
             if (this.IsVisible)
             {
-                this.Campaign.Renderer.Draw(this.background, this.Location);
+                Campaign.Renderer.Draw(this.background, this.Location);
             }
 
             foreach (Item item in this.Items)

--- a/src/Hero6/Engine/Campaigns/CampaignHandler.cs
+++ b/src/Hero6/Engine/Campaigns/CampaignHandler.cs
@@ -23,10 +23,11 @@ namespace LateStartStudio.Hero6.Engine.Campaigns
         {
             this.userInterface = userInterface;
 
+            Campaign.Renderer = Game.Renderer;
+
             this.campaigns = new List<Campaign>
             {
                 new RitesOfPassage.RitesOfPassage(
-                    Game.Renderer,
                     new MonoGameAssetManager(content),
                     this.userInterface.CurrentUi)
             };


### PR DESCRIPTION
The similar property was already static in UserInterface.cs and Game.cs, but it wasn't changed in Campaign.cs for legacy reasons.