### PR TITLE
Changed Hero6 unit tests

### DIFF
--- a/src/Hero6.DesktopGL.Tests/Hero6.DesktopGL.Tests.csproj
+++ b/src/Hero6.DesktopGL.Tests/Hero6.DesktopGL.Tests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LateStartStudio.Hero6</RootNamespace>
-    <AssemblyName>Hero6.Tests</AssemblyName>
+    <AssemblyName>Hero6.DesktopGL.Tests</AssemblyName>
     <MonoGamePlatform>DesktopGL</MonoGamePlatform>
     <MonoGameContentBuilderExe Condition=" '$(OS)' != 'Windows_NT' And Exists ('/opt/monogame-pipeline/MGCB.exe') ">/opt/monogame-pipeline/MGCB.exe</MonoGameContentBuilderExe>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>

--- a/src/Hero6.Tests/GameTests.DesktopGL.cs
+++ b/src/Hero6.Tests/GameTests.DesktopGL.cs
@@ -1,22 +1,20 @@
-﻿// <copyright file="GameTests.cs" company="Late Start Studio">
+﻿// <copyright file="GameTests.DesktopGL.cs" company="Late Start Studio">
 // Copyright (C) Late Start Studio
 // This file is subject to the terms and conditions of the MIT license specified in the file
 // 'LICENSE.CODE.md', which is a part of this source code package.
 // </copyright>
 
+#if DESKTOPGL
 namespace LateStartStudio.Hero6
 {
     using NUnit.Framework;
 
-    [TestFixture]
     public partial class GameTests
     {
-        [Test]
-        public void GraphicsApiGet()
+        partial void GraphicsApiGetPlatform()
         {
-            GraphicsApiGetPlatform();
+            Assert.That(Game.GraphicsApi, Is.EqualTo("DesktopGL"));
         }
-
-        partial void GraphicsApiGetPlatform();
     }
 }
+#endif

--- a/src/Hero6.Tests/GameTests.WindowsDX.cs
+++ b/src/Hero6.Tests/GameTests.WindowsDX.cs
@@ -1,22 +1,20 @@
-﻿// <copyright file="GameTests.cs" company="Late Start Studio">
+﻿// <copyright file="GameTests.WindowsDX.cs" company="Late Start Studio">
 // Copyright (C) Late Start Studio
 // This file is subject to the terms and conditions of the MIT license specified in the file
 // 'LICENSE.CODE.md', which is a part of this source code package.
 // </copyright>
 
+#if WINDOWSDX
 namespace LateStartStudio.Hero6
 {
     using NUnit.Framework;
 
-    [TestFixture]
     public partial class GameTests
     {
-        [Test]
-        public void GraphicsApiGet()
+        partial void GraphicsApiGetPlatform()
         {
-            GraphicsApiGetPlatform();
+            Assert.That(Game.GraphicsApi, Is.EqualTo("WindowsDX"));
         }
-
-        partial void GraphicsApiGetPlatform();
     }
 }
+#endif

--- a/src/Hero6.Tests/Hero6.Tests.projitems
+++ b/src/Hero6.Tests/Hero6.Tests.projitems
@@ -10,5 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)GameTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GameTests.DesktopGL.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GameTests.WindowsDX.cs" />
   </ItemGroup>
 </Project>

--- a/src/Hero6.Windows.sln
+++ b/src/Hero6.Windows.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.15
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hero6.WindowsDX", "Hero6.WindowsDX\Hero6.WindowsDX.csproj", "{B0B2294D-FB45-47C3-A645-6C5884E7CFAB}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -325,15 +325,19 @@ Global
 		{9C6A0DA4-892E-45C0-AFC7-B6D46F940329}.WindowsDX Release|x86.ActiveCfg = Release|Any CPU
 		{9C6A0DA4-892E-45C0-AFC7-B6D46F940329}.WindowsDX Release|x86.Build.0 = Release|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Android Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Android Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Android Debug|x86.ActiveCfg = Debug|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Android Debug|x86.Build.0 = Debug|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Android Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Android Release|Any CPU.Build.0 = Release|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Android Release|x86.ActiveCfg = Release|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Android Release|x86.Build.0 = Release|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Debug|x86.Build.0 = Debug|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Release|x86.ActiveCfg = Release|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.Release|x86.Build.0 = Release|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.WindowsDX Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -345,9 +349,11 @@ Global
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.WindowsDX Release|x86.ActiveCfg = Release|Any CPU
 		{C42A8C34-3145-41B2-B16A-D93D796DB437}.WindowsDX Release|x86.Build.0 = Release|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Android Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Android Debug|Any CPU.Build.0 = Debug|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Android Debug|x86.ActiveCfg = Debug|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Android Debug|x86.Build.0 = Debug|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Android Release|Any CPU.ActiveCfg = Release|Any CPU
+		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Android Release|Any CPU.Build.0 = Release|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Android Release|x86.ActiveCfg = Release|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Android Release|x86.Build.0 = Release|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -359,9 +365,11 @@ Global
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Release|x86.ActiveCfg = Release|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.Release|x86.Build.0 = Release|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.WindowsDX Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.WindowsDX Debug|Any CPU.Build.0 = Debug|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.WindowsDX Debug|x86.ActiveCfg = Debug|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.WindowsDX Debug|x86.Build.0 = Debug|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.WindowsDX Release|Any CPU.ActiveCfg = Release|Any CPU
+		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.WindowsDX Release|Any CPU.Build.0 = Release|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.WindowsDX Release|x86.ActiveCfg = Release|Any CPU
 		{104B4CAF-4818-45DC-A772-2F5279C73E5A}.WindowsDX Release|x86.Build.0 = Release|Any CPU
 		{5CD0CA14-E1C3-4CDA-9DEA-B22CB116DEAA}.Android Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -458,6 +466,9 @@ Global
 		{5CD0CA14-E1C3-4CDA-9DEA-B22CB116DEAA} = {CB9FBBED-6835-4C03-AC4B-60ED8763AFC9}
 		{43E058BB-A9A5-473F-AD4C-269239BA41E7} = {C7901A1A-E22C-468F-9E9A-9A891598E7D8}
 		{CB706FAB-954B-462D-8590-5433A63E14E6} = {C7901A1A-E22C-468F-9E9A-9A891598E7D8}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D79F9E72-AE93-4A79-A968-902EC57B5900}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/src/Hero6.WindowsDX.Tests/GameTests.WindowsDX.cs
+++ b/src/Hero6.WindowsDX.Tests/GameTests.WindowsDX.cs
@@ -1,22 +1,20 @@
-﻿// <copyright file="GameTests.cs" company="Late Start Studio">
+﻿// <copyright file="GameTests.WindowsDX.cs" company="Late Start Studio">
 // Copyright (C) Late Start Studio
 // This file is subject to the terms and conditions of the MIT license specified in the file
 // 'LICENSE.CODE.md', which is a part of this source code package.
 // </copyright>
 
+#if WINDOWSDX
 namespace LateStartStudio.Hero6
 {
     using NUnit.Framework;
 
-    [TestFixture]
     public partial class GameTests
     {
-        [Test]
-        public void GraphicsApiGet()
+        partial void GraphicsApiGetPlatform()
         {
-            GraphicsApiGetPlatform();
+            Assert.That(Game.GraphicsApi, Is.EqualTo("WindowsDX"));
         }
-
-        partial void GraphicsApiGetPlatform();
     }
 }
+#endif

--- a/src/Hero6.WindowsDX.Tests/Hero6.WindowsDX.Tests.csproj
+++ b/src/Hero6.WindowsDX.Tests/Hero6.WindowsDX.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LateStartStudio.Hero6</RootNamespace>
-    <AssemblyName>Hero6.Tests</AssemblyName>
+    <AssemblyName>Hero6.WindowsDX.Tests</AssemblyName>
     <MonoGamePlatform>Windows</MonoGamePlatform>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
- Added simple tests for GraphicsAPI string get
- Changed assembly name
- Both platform test projects is set to build not matter which solution config is selected. We can't involve hardware specific stuff in unit tests so it should be non-controversial